### PR TITLE
feat(websocket): emit `patient-joined` event to practitioner when patient joins consultation (#20)

### DIFF
--- a/backend/src/consultation/consultation.gateway.ts
+++ b/backend/src/consultation/consultation.gateway.ts
@@ -1,16 +1,17 @@
+import { NotFoundException } from '@nestjs/common';
 import {
   OnGatewayConnection,
   OnGatewayDisconnect,
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
-import { Server, Socket } from 'socket.io';
+import { Namespace, Server, Socket } from 'socket.io';
 import { DatabaseService } from 'src/database/database.service';
 
-@WebSocketGateway({ namespace: '/consultation', cors: true })
+@WebSocketGateway({ namespace: 'consultation', cors: true })
 export class ConsultationGateway
   implements OnGatewayConnection, OnGatewayDisconnect {
-  @WebSocketServer() server: Server;
+  @WebSocketServer() server: Namespace;
 
   constructor(private readonly databaseService: DatabaseService) { }
 
@@ -19,14 +20,60 @@ export class ConsultationGateway
    * ?consultationId=123&userId=456 in the connection URL.
    * We join them to the room and mark them active.
    */
+   async notifyPractitioner(
+    practitionerId: number,
+    payload: { consultationId: number; patientName: string; joinedAt: string },
+  ) {
+    this.server.to(`practitioner:${practitionerId}`)
+      .emit('patient-joined', payload);
+  }
+
   async handleConnection(client: Socket) {
     const cId = Number(client.handshake.query.consultationId);
     const uId = Number(client.handshake.query.userId);
     if (!cId || !uId) return;
-
     client.join(`consultation:${cId}`);
     client.data.consultationId = cId;
     client.data.userId = uId;
+
+     const user_data =  await this.databaseService.user.findFirst({
+      where: {
+           id: uId
+      }
+    })
+    const participant_data = await this.databaseService.participant.findFirst({
+      where: {
+          consultationId: cId,
+          userId: uId
+      },
+      select: {
+         isActive: true,
+         joinedAt: true
+      }
+    })
+    if(user_data?.role==='Patient' && participant_data?.isActive===true){
+        const consultation = await this.databaseService.consultation.findUnique({
+          where: { id: cId },
+          select: {
+             owner: true, 
+            startedAt: true
+            },    
+        });
+
+        if (!consultation) {
+          throw new NotFoundException('Consultation not found');
+        }
+        if (consultation.owner == null) {
+          throw new NotFoundException('Consultation owner not set');
+        }
+        const ownerId: number = consultation.owner;
+        const payload = {
+          consultationId: cId,
+          patientName: user_data.firstName ?? 'Patient',
+          joinedAt: (consultation.startedAt ?? new Date()).toISOString(),
+        };
+        await this.notifyPractitioner(ownerId, payload);
+    }
 
     await this.databaseService.participant.upsert({
       where: { consultationId_userId: { consultationId: cId, userId: uId } },


### PR DESCRIPTION
This PR implements the backend WebSocket logic to notify a practitioner in real‑time when a patient actually joins their consultation. In particular:

ConsultationGateway.handleConnection

Joins every socket to a shared room consultation:<consultationId>.

Upserts the participant record as active when they connect.

If the connecting user is a Patient whose record is already marked active, immediately calls notifyPractitioner(...).

ConsultationGateway.notifyPractitioner

Emits a patient-joined event to the room for that consultation (so only the practitioner—who is also in that room—hears it).

Payload includes:

consultationId

patientName (falls back to "Patient" if undefined)

joinedAt timestamp

ConsultationService.joinAsPatient()

After marking the participant active in the database, invokes the gateway helper to push the event.

