### PR TITLE
feat(test-call): Add Test Call page for microphone and camera verification (#37)

### DIFF
--- a/practitioner/src/app/app.routes.ts
+++ b/practitioner/src/app/app.routes.ts
@@ -2,13 +2,14 @@ import type { Routes } from '@angular/router';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { AppComponent } from './app.component';
 import { RoutePaths } from './constants/route-paths.enum';
-
+import { TestCallComponent } from './test-call/test-call.component';
 export const routes: Routes = [
   {
     path: '',
     component: AppComponent,
     children: [
       { path: '', redirectTo: RoutePaths.Dashboard, pathMatch: 'full' },
+      { path: 'test-call', component: TestCallComponent },
       { path: RoutePaths.Dashboard, component: DashboardComponent },
     ],
   },

--- a/practitioner/src/app/components/ui/button/button.component.scss
+++ b/practitioner/src/app/components/ui/button/button.component.scss
@@ -17,7 +17,7 @@ button,
 }
 
 .primary {
-    background-color: $color-primary;
+    background-color: $button-primary-color;
     color: white;
 
     &:hover {

--- a/practitioner/src/app/test-call/test-call.component.html
+++ b/practitioner/src/app/test-call/test-call.component.html
@@ -1,0 +1,30 @@
+<div class="test-call">
+    <div class="test-sections">
+        <div class="test-section micro-test">
+            <h2>MICRO TEST</h2>
+            <div class="audio-meter-container">
+                <div class="audio-meter">
+                    <div #audioMeter class="meter-fill"></div>
+                </div>
+            </div>
+            <p class="help-text">
+                A properly tuned microphone should put the VU meter in the green center area when speaking.
+            </p>
+
+            <div class="device-selection" *ngIf="audioInputDevices.length > 1">
+                <select id="audioInput" (change)="switchAudioInput($event)">
+                    <option *ngFor="let device of audioInputDevices" [value]="device.deviceId">
+                        {{ device.label || 'Unknown Device' }}
+                    </option>
+                </select>
+            </div>
+        </div>
+
+        <div class="test-section camera-test">
+            <h2>CAMERA TEST</h2>
+            <div class="video-container">
+                <video #videoPreview autoplay playsinline muted></video>
+            </div>
+        </div>
+    </div>
+</div>

--- a/practitioner/src/app/test-call/test-call.component.scss
+++ b/practitioner/src/app/test-call/test-call.component.scss
@@ -1,0 +1,90 @@
+@use './variables' as *;
+
+.test-call {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+    background-color: $color-background-card;
+
+    .test-sections {
+        display: flex;
+        width: 100%;
+        max-width: 1200px;
+        gap: 20px;
+
+        @media (max-width: 768px) {
+            flex-direction: column;
+        }
+    }
+
+    .test-section {
+        flex: 1;
+        padding: 20px;
+        border: 1px solid $color-border;
+        border-radius: 4px;
+
+        h2 {
+            font-size: 20px;
+            font-weight: bold;
+            margin-bottom: 20px;
+            color: $color-heading;
+        }
+    }
+
+    .micro-test {
+        .audio-meter-container {
+            width: 100%;
+            margin-bottom: 15px;
+
+            .audio-meter {
+                width: 100%;
+                height: 10px;
+                background-color: $color-surface;
+                border-radius: 5px;
+                overflow: hidden;
+                border: 1px solid $color-border-light;
+
+                .meter-fill {
+                    height: 100%;
+                    width: 0;
+                    background-color: $color-success;
+                    transition: width 0.1s linear;
+                }
+            }
+        }
+
+        .help-text {
+            color: $color-primary;
+            font-size: 14px;
+            margin-bottom: 20px;
+            line-height: 1.5;
+        }
+
+        .device-selection {
+            margin-top: 15px;
+
+            select {
+                width: 100%;
+                padding: 8px;
+                border: 1px solid #ccc; 
+                border-radius: 4px;
+                font-size: 14px;
+            }
+        }
+    }
+
+    .camera-test {
+        .video-container {
+            width: 100%;
+
+            video {
+                width: 100%;
+                border: 1px solid $color-border-light;
+                border-radius: 4px;
+                background-color: $color-empty-state-bg;
+                min-height: 240px;
+            }
+        }
+    }
+}

--- a/practitioner/src/app/test-call/test-call.component.spec.ts
+++ b/practitioner/src/app/test-call/test-call.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TestCallComponent } from './test-call.component';
+
+describe('TestCallComponent', () => {
+  let component: TestCallComponent;
+  let fixture: ComponentFixture<TestCallComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestCallComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TestCallComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/practitioner/src/app/test-call/test-call.component.ts
+++ b/practitioner/src/app/test-call/test-call.component.ts
@@ -1,0 +1,112 @@
+import {
+  Component,
+  OnInit,
+  AfterViewInit,
+  ViewChild,
+  ElementRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-test-call',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './test-call.component.html',
+  styleUrls: ['./test-call.component.scss'],
+})
+export class TestCallComponent implements OnInit, AfterViewInit {
+  @ViewChild('videoPreview', { static: false })
+  videoPreview!: ElementRef<HTMLVideoElement>;
+  @ViewChild('audioMeter', { static: false })
+  audioMeter!: ElementRef<HTMLDivElement>;
+
+  audioInputDevices: MediaDeviceInfo[] = [];
+  selectedAudioDeviceId: string | null = null;
+
+  audioContext?: AudioContext;
+  analyser?: AnalyserNode;
+  microphoneStream?: MediaStreamAudioSourceNode;
+  mediaStream?: MediaStream;
+
+  async ngOnInit(): Promise<void> {
+    await this.enumerateAudioDevices();
+  }
+
+  ngAfterViewInit(): void {
+    this.startMedia();
+  }
+
+  async startMedia() {
+    try {
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: true,
+        audio: true,
+      });
+      this.videoPreview.nativeElement.srcObject = this.mediaStream;
+      this.audioContext = new AudioContext();
+      this.microphoneStream = this.audioContext.createMediaStreamSource(
+        this.mediaStream
+      );
+      this.analyser = this.audioContext.createAnalyser();
+      this.analyser.fftSize = 256;
+      this.microphoneStream.connect(this.analyser);
+      this.updateAudioMeter();
+    } catch (err) {
+      console.error('Error accessing media devices', err);
+    }
+  }
+
+  updateAudioMeter() {
+    if (!this.analyser) {
+      return;
+    }
+    const dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+    this.analyser.getByteFrequencyData(dataArray);
+    const avg =
+      dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
+    if (this.audioMeter && this.audioMeter.nativeElement) {
+      this.audioMeter.nativeElement.style.width = (avg / 255) * 100 + '%';
+    }
+    requestAnimationFrame(() => this.updateAudioMeter());
+  }
+
+  async enumerateAudioDevices() {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      this.audioInputDevices = devices.filter(
+        (device) => device.kind === 'audioinput'
+      );
+      if (this.audioInputDevices.length > 0) {
+        this.selectedAudioDeviceId = this.audioInputDevices[0].deviceId;
+      }
+    } catch (err) {
+      console.error('Error enumerating devices', err);
+    }
+  }
+
+  async switchAudioInput(event: Event): Promise<void> {
+    const selectElement = event.target as HTMLSelectElement;
+    const deviceId = selectElement.value;
+    if (this.mediaStream) {
+      this.mediaStream.getAudioTracks().forEach((track) => track.stop());
+    }
+    try {
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: true,
+        audio: { deviceId: { exact: deviceId } },
+      });
+      this.videoPreview.nativeElement.srcObject = this.mediaStream;
+      if (this.audioContext && this.analyser) {
+        if (this.microphoneStream) {
+          this.microphoneStream.disconnect();
+        }
+        this.microphoneStream = this.audioContext.createMediaStreamSource(
+          this.mediaStream
+        );
+        this.microphoneStream.connect(this.analyser);
+      }
+    } catch (err) {
+      console.error('Error switching audio device', err);
+    }
+  }
+}

--- a/practitioner/src/styles/variables/_buttons.scss
+++ b/practitioner/src/styles/variables/_buttons.scss
@@ -1,4 +1,4 @@
-$color-primary: #4169e1;
+$button-primary-color: #4CAF50;
 $color-primary-hover: #3a5fcd;
 $color-secondary-bg: #eeeeee;
 $color-secondary-hover: #dddddd;

--- a/practitioner/src/styles/variables/_colors.scss
+++ b/practitioner/src/styles/variables/_colors.scss
@@ -6,3 +6,8 @@ $color-description: #666666;
 $color-empty-state-bg: #f9f9f9;
 $color-empty-state-text: #888888;
 $color-border-bottom: #f0f0f0;
+$color-primary: #2196F3;
+$color-success: #4CAF50;
+$color-border: #e0e0e0;
+$color-border-light: #ddd;
+$color-surface: #eee;


### PR DESCRIPTION
### Description

This PR adds a **Test Call** page for practitioners to verify their microphone and camera setup before entering real consultations.

### Features Implemented
- Added "Test Call" page.
- On load: Requests camera and microphone access.
- Shows:
  - Live camera preview
  - Real-time microphone input volume meter
-  Device selection logic implemented where supported

### Linked Issue
Closes #37 

### Testing Steps
- Visit `/test-call` after login
- Allow permissions
- Speak and check mic input level
- Switch mic if needed

### Screenshot
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/161a461a-244f-4c82-8bb4-ebe0ebc722a7" />
