### PR TITLE
# Add Terms and TermsAcceptance Models for Managing Legal Agreements

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,29 @@ enum ConsultationStatus {
   CANCELLED
 }
 
+model Terms {
+  id          Int   @id @default(autoincrement())
+  language    String
+  country     String
+  content     String   @db.Text
+  version     Int      @default(1)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  isActive    Boolean  @default(true)  
+  @@unique([language, country, version])
+  acceptances TermsAcceptance[]
+}
+
+model TermsAcceptance {
+  id        Int   @id @default(autoincrement())
+  userId    Int
+  termsId   Int
+  acceptedAt DateTime @default(now())
+  terms     Terms    @relation(fields: [termsId], references: [id])
+  user      User     @relation(fields: [userId], references: [id]) 
+  @@unique([userId, termsId])
+}
+
 model User {
   id               Int           @id @default(autoincrement())
   role             Role          @default(Patient) // Enum: Patient, Practitioner, Admin
@@ -28,6 +51,7 @@ model User {
   sex              Sex // Enum: male, female, other
   status           Status        @default(not_approved) // Enum: approved, not_approved
   Participant      Participant[]
+  termsAcceptances TermsAcceptance[]
 }
 
 enum Role {


### PR DESCRIPTION
## Description
This PR introduces two new models to our Prisma schema to handle Terms of Service/Privacy Policy acceptance tracking:
Fixes sub Issue of - #9
### Models

- **Terms**: 
  - Stores different versions of legal terms by language and country.

- **TermsAcceptance**: 
  - Tracks when users accept specific terms versions.

### Updates
- Updated the User model with a relation to track which terms users have accepted.