### PR TITLE
Feature: Add support for experts and guests in consultations (Issue #24)

### DIFF
--- a/README-toast.md
+++ b/README-toast.md
@@ -1,0 +1,86 @@
+# Toast Notification System
+
+This document explains how to use the global toast notification system implemented across the HCW-home platform.
+
+## Overview
+
+The toast notification system provides a consistent way to display feedback messages to users across all applications. It supports three types of notifications:
+
+- **Success** (green): Confirms successful operations
+- **Error** (red): Indicates errors and problems
+- **Warning** (yellow): Displays warnings or important notices
+
+## Implementation
+
+The system has been implemented in all three applications (admin, practitioner, and patient) with a consistent approach:
+
+1. **ToastService**: A service that manages toast messages
+2. **ToastComponent**: A UI component that displays the toast messages
+3. **ToastInterceptor**: An HTTP interceptor that automatically shows success/error messages based on API responses
+
+## How to Use
+
+### Automatic Toast Notifications (via HTTP Interceptor)
+
+Toast notifications will be automatically displayed for:
+
+- **Errors**: When an API call fails, an error toast is shown with the error message
+- **Success**: When a POST/PUT/DELETE API call succeeds, a success toast is shown
+
+The error message is extracted from `error.error.message`, falling back to "An error occurred" if no message is provided.
+The success message is extracted from `response.body.message`, falling back to "Operation completed successfully" if no message is provided.
+
+### Manual Toast Notifications
+
+You can manually trigger toast notifications from any component or service by injecting the `ToastService`:
+
+```typescript
+import { Component } from '@angular/core';
+import { ToastService } from 'path/to/services/toast.service';
+
+@Component({
+  selector: 'app-example',
+  template: '...'
+})
+export class ExampleComponent {
+  constructor(private toastService: ToastService) {}
+
+  showSuccess() {
+    this.toastService.show('Operation completed successfully', 'success');
+  }
+
+  showError() {
+    this.toastService.show('Something went wrong', 'error');
+  }
+
+  showWarning() {
+    this.toastService.show('Please review your data', 'warning');
+  }
+}
+```
+
+## Customizing the Toast Service
+
+The ToastService supports the following methods:
+
+- `show(message: string, type: 'success' | 'error' | 'warning' = 'success')`: Displays a toast with the specified message and type
+- `hide()`: Manually hides the currently displayed toast
+
+By default, toasts automatically disappear after 3 seconds, but you can manually hide them earlier if needed.
+
+## UI Appearance
+
+The toast notifications are positioned at:
+- **Admin/Practitioner**: Bottom right corner of the screen
+- **Patient**: Bottom center of the screen
+
+Each toast type has its own distinct color to help users quickly identify the message type:
+- Success: Green
+- Error: Red
+- Warning: Yellow/Orange
+
+## Styling Customization
+
+If you need to customize the appearance of the toast notifications, you can modify:
+- For admin and practitioner: The SCSS files at `src/app/components/toast/toast.component.scss`
+- For patient: The inline styles in `src/app/components/toast/toast.component.ts` 

--- a/admin/src/app/app.component.html
+++ b/admin/src/app/app.component.html
@@ -1,0 +1,1 @@
+<app-toast></app-toast>

--- a/admin/src/app/app.component.html
+++ b/admin/src/app/app.component.html
@@ -1,1 +1,2 @@
 <app-toast></app-toast>
+<router-outlet></router-outlet>

--- a/admin/src/app/app.component.ts
+++ b/admin/src/app/app.component.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { ToastComponent } from './components/toast/toast.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  standalone: true,
+  imports: [RouterOutlet, ToastComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/admin/src/app/app.config.ts
+++ b/admin/src/app/app.config.ts
@@ -1,8 +1,16 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { ToastInterceptor } from './interceptors/toast.interceptor';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideHttpClient(withInterceptors([
+      (req, next) => new ToastInterceptor(new (window as any).ng.injector.get('ToastService')).intercept(req, next)
+    ]))
+  ]
 };

--- a/admin/src/app/app.config.ts
+++ b/admin/src/app/app.config.ts
@@ -1,16 +1,14 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptors } from '@angular/common/http';
-import { ToastInterceptor } from './interceptors/toast.interceptor';
-
+import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { routes } from './app.routes';
+import { ToastInterceptor } from './interceptors/toast.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([
-      (req, next) => new ToastInterceptor(new (window as any).ng.injector.get('ToastService')).intercept(req, next)
-    ]))
+    provideHttpClient(withInterceptorsFromDi()),
+    { provide: HTTP_INTERCEPTORS, useClass: ToastInterceptor, multi: true }
   ]
 };

--- a/admin/src/app/app.routes.ts
+++ b/admin/src/app/app.routes.ts
@@ -1,3 +1,8 @@
 import { Routes } from '@angular/router';
+import { ToastTestComponent } from './components/toast-test/toast-test.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'toast-demo', component: ToastTestComponent },
+  // Default landing page will be determined by the actual application
+  { path: '', redirectTo: '/toast-demo', pathMatch: 'full' }
+];

--- a/admin/src/app/components/toast-test/toast-test.component.ts
+++ b/admin/src/app/components/toast-test/toast-test.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-toast-test',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div style="padding: 20px;">
+      <h2>Toast Notification Demo</h2>
+      
+      <div style="display: flex; gap: 10px; margin: 20px 0;">
+        <button style="padding: 8px 16px;" (click)="showSuccess()">Show Success</button>
+        <button style="padding: 8px 16px;" (click)="showError()">Show Error</button>
+        <button style="padding: 8px 16px;" (click)="showWarning()">Show Warning</button>
+      </div>
+    </div>
+  `
+})
+export class ToastTestComponent {
+  constructor(private toastService: ToastService) {}
+
+  showSuccess() {
+    this.toastService.show('Operation completed successfully', 'success');
+  }
+
+  showError() {
+    this.toastService.show('An error occurred', 'error');
+  }
+
+  showWarning() {
+    this.toastService.show('Please review before proceeding', 'warning');
+  }
+} 

--- a/admin/src/app/components/toast/toast.component.scss
+++ b/admin/src/app/components/toast/toast.component.scss
@@ -1,0 +1,19 @@
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 200px;
+  max-width: 90vw;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 1rem;
+  z-index: 1000;
+  opacity: 0.95;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  transition: all 0.3s;
+}
+.toast.success { background: #43a047; }
+.toast.error   { background: #e53935; }
+.toast.warning { background: #ffa000; color: #333; }

--- a/admin/src/app/components/toast/toast.component.scss
+++ b/admin/src/app/components/toast/toast.component.scss
@@ -1,19 +1,65 @@
 .toast {
   position: fixed;
   bottom: 2rem;
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 200px;
-  max-width: 90vw;
-  padding: 1rem 2rem;
+  right: 2rem;
+  min-width: 250px;
+  max-width: 400px;
+  padding: 1rem;
   border-radius: 8px;
   color: #fff;
   font-size: 1rem;
   z-index: 1000;
   opacity: 0.95;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
   transition: all 0.3s;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  animation: slide-in 0.3s ease-out;
 }
+
+.toast-content {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+}
+
+.toast-icon {
+  margin-right: 10px;
+}
+
+.toast-message {
+  font-weight: 500;
+}
+
+.toast-close {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.5rem;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+  padding: 0;
+  margin-left: 10px;
+  line-height: 1;
+}
+
+.toast-close:hover {
+  opacity: 1;
+}
+
 .toast.success { background: #43a047; }
-.toast.error   { background: #e53935; }
+.toast.error { background: #e53935; }
 .toast.warning { background: #ffa000; color: #333; }
+
+@keyframes slide-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 0.95;
+  }
+}

--- a/admin/src/app/components/toast/toast.component.ts
+++ b/admin/src/app/components/toast/toast.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div *ngIf="toastService.toast$ | async as toast" class="toast" [ngClass]="toast.type">
+      {{ toast.message }}
+    </div>
+  `,
+  styleUrls: ['./toast.component.scss']
+})
+export class ToastComponent {
+  constructor(public toastService: ToastService) {}
+}

--- a/admin/src/app/components/toast/toast.component.ts
+++ b/admin/src/app/components/toast/toast.component.ts
@@ -8,7 +8,15 @@ import { ToastService } from '../../services/toast.service';
   imports: [CommonModule],
   template: `
     <div *ngIf="toastService.toast$ | async as toast" class="toast" [ngClass]="toast.type">
-      {{ toast.message }}
+      <div class="toast-content">
+        <span class="toast-icon">
+          <i *ngIf="toast.type === 'success'" class="fas fa-check-circle"></i>
+          <i *ngIf="toast.type === 'error'" class="fas fa-times-circle"></i>
+          <i *ngIf="toast.type === 'warning'" class="fas fa-exclamation-triangle"></i>
+        </span>
+        <span class="toast-message">{{ toast.message }}</span>
+      </div>
+      <button class="toast-close" (click)="toastService.hide()">×</button>
     </div>
   `,
   styleUrls: ['./toast.component.scss']

--- a/admin/src/app/interceptors/toast.interceptor.ts
+++ b/admin/src/app/interceptors/toast.interceptor.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpInterceptor,
+  HttpHandler,
+  HttpRequest,
+  HttpErrorResponse
+} from '@angular/common/http';
+import { Observable, catchError, tap } from 'rxjs';
+import { ToastService } from '../services/toast.service';
+
+@Injectable()
+export class ToastInterceptor implements HttpInterceptor {
+  constructor(private toast: ToastService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      tap(event => {
+        // Optionally: Show success toasts for certain responses
+      }),
+      catchError((error: HttpErrorResponse) => {
+        this.toast.show(error.error?.message || 'An error occurred', 'error');
+        throw error;
+      })
+    );
+  }
+}

--- a/admin/src/app/services/toast.service.ts
+++ b/admin/src/app/services/toast.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export type ToastType = 'success' | 'error' | 'warning';
+
+export interface ToastMessage {
+  message: string;
+  type: ToastType;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private toastSubject = new BehaviorSubject<ToastMessage | null>(null);
+
+  toast$ = this.toastSubject.asObservable();
+
+  show(message: string, type: ToastType = 'success') {
+    this.toastSubject.next({ message, type });
+    setTimeout(() => this.hide(), 3000); // auto-hide after 3s
+  }
+
+  hide() {
+    this.toastSubject.next(null);
+  }
+}

--- a/admin/src/index.html
+++ b/admin/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
 <body>
   <app-root></app-root>

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,8 +29,11 @@
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/websockets": "^11.0.15",
     "@prisma/client": "^6.6.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,18 +16,21 @@ enum ConsultationStatus {
 }
 
 model User {
-  id               Int           @id @default(autoincrement())
-  role             Role          @default(Patient) // Enum: Patient, Practitioner, Admin
-  firstName        String
-  lastName         String
-  password         String
-  temporaryAccount Boolean
-  phoneNumber      String        @unique()
-  country          String
-  language         String
-  sex              Sex // Enum: male, female, other
-  status           Status        @default(not_approved) // Enum: approved, not_approved
-  Participant      Participant[]
+  id                     Int           @id @default(autoincrement())
+  role                   Role          @default(Patient) // Enum: Patient, Practitioner, Admin
+  firstName              String
+  lastName               String
+  password               String
+  temporaryAccount       Boolean
+  phoneNumber            String        @unique()
+  country                String
+  language               String
+  sex                    Sex // Enum: male, female, other
+  status                 Status        @default(not_approved) // Enum: approved, not_approved
+  notificationsEnabled   Boolean       @default(false)
+  notificationPhoneNumber String?
+  preferredNotificationChannel MessageService?
+  Participant            Participant[]
 }
 
 enum Role {
@@ -56,6 +59,13 @@ enum MessageService {
   MANUALLY
 }
 
+enum ParticipantRole {
+  PATIENT
+  PRACTITIONER
+  EXPERT
+  GUEST
+}
+
 model Consultation {
   id                 Int                @id @default(autoincrement())
   scheduledDate      DateTime?
@@ -72,13 +82,16 @@ model Consultation {
 }
 
 model Participant {
-  id             Int          @id @default(autoincrement())
+  id             Int             @id @default(autoincrement())
   consultationId Int
   userId         Int
-  isActive       Boolean      @default(false)
+  role           ParticipantRole @default(PATIENT)
+  isActive       Boolean         @default(false)
   joinedAt       DateTime?
-  consultation   Consultation @relation(fields: [consultationId], references: [id])
-  user           User         @relation(fields: [userId], references: [id])
+  notes          String?
+  magicLink      String?
+  consultation   Consultation    @relation(fields: [consultationId], references: [id])
+  user           User            @relation(fields: [userId], references: [id])
 
   @@unique([consultationId, userId])
 }

--- a/backend/src/consultation/consultation.controller.ts
+++ b/backend/src/consultation/consultation.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Param, ParseIntPipe, Post, Request } from '@nestjs/common';
 import { ConsultationService } from './consultation.service';
+import { ParticipantRole } from '@prisma/client';
 
 @Controller('consultation')
 export class ConsultationController {
@@ -20,10 +21,107 @@ export class ConsultationController {
         return {message: 'Practitioner joined consultation. ', ...res}
     }
 
+    @Post(':id/join/participant')
+    async joinAsParticipant(@Param('id', ParseIntPipe) id: number, @Body('userId') userId: number) {
+        const res = await this.consultationService.joinAsParticipant(id, userId);
+
+        return { message: 'Participant joined consultation.', ...res };
+    }
+
+    @Post(':id/participants')
+    async addParticipant(
+        @Param('id', ParseIntPipe) id: number,
+        @Body('userId') userId: number,
+        @Body('role') role: ParticipantRole,
+        @Body('notes') notes?: string
+    ) {
+        const participant = await this.consultationService.addParticipant(id, userId, role, notes);
+        return { 
+            message: 'Participant added to consultation.', 
+            success: true, 
+            participant 
+        };
+    }
+
+    @Post(':id/participants/batch')
+    async addMultipleParticipants(
+        @Param('id', ParseIntPipe) id: number,
+        @Body('participants') participants: Array<{userId: number, role: ParticipantRole, notes?: string}>
+    ) {
+        const results = await this.consultationService.addMultipleParticipants(id, participants);
+        return { 
+            message: 'Multiple participants added to consultation.', 
+            success: true, 
+            participants: results 
+        };
+    }
+
+    @Get(':id/participants')
+    async getConsultationParticipants(@Param('id', ParseIntPipe) id: number) {
+        const participants = await this.consultationService.getConsultationParticipants(id);
+        return { success: true, participants };
+    }
+
     @Get('/waiting-room')
     async getWaitingRoom(@Body('userId') userId: number) {
         const consultations = await this.consultationService.getWaitingRoomConsultations(userId);
         return {success: true, consultations};
     }
 
+    @Post(':id/participants/invite')
+    async inviteExternalParticipant(
+        @Param('id', ParseIntPipe) id: number,
+        @Body('firstName') firstName: string,
+        @Body('lastName') lastName: string,
+        @Body('contactInfo') contactInfo: string,
+        @Body('role') role: ParticipantRole,
+        @Body('notes') notes?: string
+    ) {
+        const result = await this.consultationService.inviteExternalParticipant(
+            id, 
+            firstName, 
+            lastName, 
+            contactInfo, 
+            role, 
+            notes
+        );
+        
+        return { 
+            message: 'External participant invited to consultation.', 
+            success: true, 
+            ...result
+        };
+    }
+
+    @Post(':id/participants/invite/batch')
+    async inviteMultipleExternalParticipants(
+        @Param('id', ParseIntPipe) id: number,
+        @Body('participants') participants: Array<{
+            firstName: string,
+            lastName: string,
+            contactInfo: string,
+            role: ParticipantRole,
+            notes?: string
+        }>
+    ) {
+        const results = [];
+        
+        for (const participant of participants) {
+            const result = await this.consultationService.inviteExternalParticipant(
+                id,
+                participant.firstName,
+                participant.lastName,
+                participant.contactInfo,
+                participant.role,
+                participant.notes
+            );
+            results.push(result);
+        }
+        
+        return { 
+            message: 'Multiple external participants invited to consultation.', 
+            success: true, 
+            results 
+        };
+    }
 }

--- a/backend/src/consultation/consultation.gateway.ts
+++ b/backend/src/consultation/consultation.gateway.ts
@@ -3,6 +3,7 @@ import {
   OnGatewayDisconnect,
   WebSocketGateway,
   WebSocketServer,
+  SubscribeMessage,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { DatabaseService } from 'src/database/database.service';
@@ -28,24 +29,60 @@ export class ConsultationGateway
     client.data.consultationId = cId;
     client.data.userId = uId;
 
-    await this.databaseService.participant.upsert({
+    // Get user info
+    const user = await this.databaseService.user.findUnique({
+      where: { id: uId },
+      select: { firstName: true, lastName: true, role: true }
+    });
+
+    // Update participant status
+    const participant = await this.databaseService.participant.upsert({
       where: { consultationId_userId: { consultationId: cId, userId: uId } },
       create: { consultationId: cId, userId: uId, isActive: true, joinedAt: new Date() },
       update: { isActive: true },
+      include: { user: { select: { firstName: true, lastName: true } } }
+    });
+
+    // Emit a participant joined event to all clients in the room
+    this.server.to(`consultation:${cId}`).emit('participant_joined', {
+      participantId: participant.id,
+      userId: participant.userId,
+      role: participant.role,
+      name: `${user.firstName} ${user.lastName}`,
+      joinedAt: participant.joinedAt,
+      timestamp: new Date()
     });
   }
 
   /**
-   * On disconnect, mark them inactive.
+   * On disconnect, mark them inactive and notify others.
    */
   async handleDisconnect(client: Socket) {
     const { consultationId, userId } = client.data;
     if (!consultationId || !userId) return;
 
-    await this.databaseService.participant.updateMany({
-      where: { consultationId, userId },
-      data: { isActive: false },
+    // Get participant and user info before updating
+    const participant = await this.databaseService.participant.findUnique({
+      where: { consultationId_userId: { consultationId, userId } },
+      include: { user: { select: { firstName: true, lastName: true } } }
     });
+
+    if (participant) {
+      // Update participant status
+      await this.databaseService.participant.updateMany({
+        where: { consultationId, userId },
+        data: { isActive: false },
+      });
+
+      // Emit a participant left event to all clients in the room
+      this.server.to(`consultation:${consultationId}`).emit('participant_left', {
+        participantId: participant.id,
+        userId: participant.userId,
+        role: participant.role,
+        name: `${participant.user.firstName} ${participant.user.lastName}`,
+        timestamp: new Date()
+      });
+    }
 
     const activePatients = await this.databaseService.participant.findMany({
       where: {
@@ -65,6 +102,189 @@ export class ConsultationGateway
         data: { status: 'SCHEDULED' },
       });
     }
+  }
 
+  /**
+   * Allows practitioners to add participants during a live consultation
+   */
+  @SubscribeMessage('add_participant')
+  async handleAddParticipant(client: Socket, payload: { 
+    userId: number, 
+    role: string, 
+    notes?: string 
+  }) {
+    const { consultationId } = client.data;
+    if (!consultationId) return { success: false, error: 'No consultation ID' };
+
+    try {
+      // Verify the current user is allowed to add participants (should be practitioner)
+      const practitionerCheck = await this.databaseService.consultation.findFirst({
+        where: {
+          id: consultationId,
+          owner: client.data.userId
+        }
+      });
+
+      if (!practitionerCheck) {
+        return { success: false, error: 'Only the practitioner can add participants' };
+      }
+
+      // Create the participant
+      const magicLink = `${process.env.FRONTEND_URL || 'http://localhost:4200'}/join/${consultationId}/${Buffer.from(`${payload.userId}-${Date.now()}`).toString('base64')}`;
+      
+      const participant = await this.databaseService.participant.upsert({
+        where: { consultationId_userId: { consultationId, userId: payload.userId } },
+        create: { 
+          consultationId, 
+          userId: payload.userId, 
+          role: payload.role, 
+          notes: payload.notes,
+          magicLink, 
+          isActive: false 
+        },
+        update: { 
+          role: payload.role, 
+          notes: payload.notes,
+          magicLink 
+        },
+        include: {
+          user: {
+            select: {
+              firstName: true,
+              lastName: true,
+              email: true,
+              phoneNumber: true
+            }
+          }
+        }
+      });
+
+      // Notify all clients in this consultation about the new participant
+      this.server.to(`consultation:${consultationId}`).emit('participant_invited', {
+        participantId: participant.id,
+        userId: participant.userId,
+        role: participant.role,
+        name: `${participant.user.firstName} ${participant.user.lastName}`,
+        timestamp: new Date()
+      });
+
+      return {
+        success: true,
+        participant: {
+          id: participant.id,
+          user: participant.user,
+          role: participant.role,
+          magicLink
+        }
+      };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  }
+
+  /**
+   * Allows practitioners to invite external participants during a live consultation
+   */
+  @SubscribeMessage('invite_external_participant')
+  async handleInviteExternalParticipant(client: Socket, payload: { 
+    firstName: string,
+    lastName: string,
+    contactInfo: string,
+    role: string, 
+    notes?: string 
+  }) {
+    const { consultationId } = client.data;
+    if (!consultationId) return { success: false, error: 'No consultation ID' };
+
+    try {
+      // Verify the current user is allowed to add participants (should be practitioner)
+      const practitionerCheck = await this.databaseService.consultation.findFirst({
+        where: {
+          id: consultationId,
+          owner: client.data.userId
+        }
+      });
+
+      if (!practitionerCheck) {
+        return { success: false, error: 'Only the practitioner can add participants' };
+      }
+
+      // Generate a random password for temporary accounts
+      const tempPassword = Math.random().toString(36).slice(-8);
+      
+      // Check if user already exists with this contact info
+      let user = await this.databaseService.user.findFirst({
+        where: { phoneNumber: payload.contactInfo }
+      });
+      
+      // If user doesn't exist, create a temporary account
+      if (!user) {
+        user = await this.databaseService.user.create({
+          data: {
+            firstName: payload.firstName,
+            lastName: payload.lastName,
+            phoneNumber: payload.contactInfo, // Using phoneNumber as the unique identifier
+            password: tempPassword, // In a real system, this should be hashed
+            temporaryAccount: true,
+            country: 'Unknown', // Default values
+            language: 'en',
+            sex: 'other',
+            role: 'Patient', // Default role
+          }
+        });
+      }
+      
+      // Create the participant
+      const magicLink = `${process.env.FRONTEND_URL || 'http://localhost:4200'}/join/${consultationId}/${Buffer.from(`${user.id}-${Date.now()}`).toString('base64')}`;
+      
+      const participant = await this.databaseService.participant.upsert({
+        where: { consultationId_userId: { consultationId, userId: user.id } },
+        create: { 
+          consultationId, 
+          userId: user.id, 
+          role: payload.role, 
+          notes: payload.notes,
+          magicLink, 
+          isActive: false 
+        },
+        update: { 
+          role: payload.role, 
+          notes: payload.notes,
+          magicLink 
+        },
+        include: {
+          user: {
+            select: {
+              firstName: true,
+              lastName: true,
+              phoneNumber: true
+            }
+          }
+        }
+      });
+
+      // Notify all clients in this consultation about the new participant
+      this.server.to(`consultation:${consultationId}`).emit('participant_invited', {
+        participantId: participant.id,
+        userId: participant.userId,
+        role: participant.role,
+        name: `${participant.user.firstName} ${participant.user.lastName}`,
+        contactInfo: participant.user.phoneNumber,
+        timestamp: new Date(),
+        isNewUser: !user
+      });
+
+      return {
+        success: true,
+        participant: {
+          id: participant.id,
+          user: participant.user,
+          role: participant.role,
+          magicLink
+        }
+      };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
   }
 }

--- a/backend/src/consultation/consultation.service.ts
+++ b/backend/src/consultation/consultation.service.ts
@@ -4,7 +4,8 @@ import {
     NotFoundException,
 } from '@nestjs/common';
 import { DatabaseService } from 'src/database/database.service';
-import { ConsultationStatus } from '@prisma/client';
+import { ConsultationStatus, ParticipantRole } from '@prisma/client';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class ConsultationService {
@@ -123,5 +124,232 @@ export class ConsultationService {
             },
             orderBy: { scheduledDate: 'asc' },
         });
+    }
+
+    /**
+     * Adds a new participant (expert or guest) to a consultation
+     * 
+     * @param consultationId The ID of the consultation
+     * @param userId The ID of the user to add
+     * @param role The role of the participant (EXPERT or GUEST)
+     * @param notes Optional notes about the participant
+     * @returns The created participant with magic link
+     */
+    async addParticipant(consultationId: number, userId: number, role: ParticipantRole, notes?: string) {
+        const consultation = await this.db.consultation.findUnique({ 
+            where: { id: consultationId } 
+        });
+        
+        if (!consultation) throw new NotFoundException('Consultation not found');
+
+        const user = await this.db.user.findUnique({ 
+            where: { id: userId } 
+        });
+        
+        if (!user) throw new NotFoundException('User does not exist');
+
+        // Generate a unique magic link
+        const magicLink = `${process.env.FRONTEND_URL || 'http://localhost:4200'}/join/${consultationId}/${uuidv4()}`;
+
+        const participant = await this.db.participant.upsert({
+            where: { 
+                consultationId_userId: { consultationId, userId } 
+            },
+            create: { 
+                consultationId, 
+                userId, 
+                role, 
+                notes, 
+                magicLink,
+                isActive: false
+            },
+            update: { 
+                role, 
+                notes,
+                magicLink 
+            },
+        });
+
+        return participant;
+    }
+
+    /**
+     * Adds multiple participants to a consultation
+     * 
+     * @param consultationId The ID of the consultation
+     * @param participants Array of participant data (userId, role, notes)
+     * @returns Array of created participants with magic links
+     */
+    async addMultipleParticipants(consultationId: number, participants: Array<{userId: number, role: ParticipantRole, notes?: string}>) {
+        const results = [];
+        
+        for (const participant of participants) {
+            const result = await this.addParticipant(
+                consultationId,
+                participant.userId,
+                participant.role,
+                participant.notes
+            );
+            results.push(result);
+        }
+        
+        return results;
+    }
+
+    /**
+     * Joins a consultation as an expert or guest
+     * 
+     * @param consultationId The ID of the consultation
+     * @param userId The ID of the user joining
+     * @returns Object with success status and consultation ID
+     */
+    async joinAsParticipant(consultationId: number, userId: number) {
+        const consultation = await this.db.consultation.findUnique({ 
+            where: { id: consultationId },
+            include: { 
+                participants: { 
+                    where: { userId } 
+                } 
+            }
+        });
+        
+        if (!consultation) throw new NotFoundException('Consultation not found');
+
+        const participant = consultation.participants[0];
+        if (!participant) throw new NotFoundException('You are not invited to this consultation');
+
+        // Only allow joining if the consultation is active or waiting
+        if (consultation.status !== ConsultationStatus.WAITING && 
+            consultation.status !== ConsultationStatus.ACTIVE) {
+            throw new ForbiddenException('Consultation is not active or in waiting room');
+        }
+
+        await this.db.participant.update({
+            where: { id: participant.id },
+            data: { 
+                isActive: true, 
+                joinedAt: new Date() 
+            },
+        });
+
+        return { success: true, consultationId };
+    }
+
+    /**
+     * Get all participants for a consultation
+     * 
+     * @param consultationId The ID of the consultation
+     * @returns Array of participants with user details
+     */
+    async getConsultationParticipants(consultationId: number) {
+        const consultation = await this.db.consultation.findUnique({
+            where: { id: consultationId },
+            include: {
+                participants: {
+                    include: {
+                        user: {
+                            select: {
+                                id: true,
+                                firstName: true,
+                                lastName: true,
+                                role: true
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        if (!consultation) throw new NotFoundException('Consultation not found');
+
+        return consultation.participants;
+    }
+
+    /**
+     * Creates a temporary user for an external participant and adds them to a consultation
+     * 
+     * @param consultationId The ID of the consultation
+     * @param firstName First name of the participant
+     * @param lastName Last name of the participant
+     * @param contactInfo Phone number or email of the participant
+     * @param role The role of the participant (EXPERT or GUEST)
+     * @param notes Optional notes about the participant
+     * @returns The created participant with magic link
+     */
+    async inviteExternalParticipant(
+        consultationId: number, 
+        firstName: string, 
+        lastName: string, 
+        contactInfo: string, 
+        role: ParticipantRole, 
+        notes?: string
+    ) {
+        const consultation = await this.db.consultation.findUnique({ 
+            where: { id: consultationId } 
+        });
+        
+        if (!consultation) throw new NotFoundException('Consultation not found');
+
+        // Check if this is an email or phone number
+        const isEmail = contactInfo.includes('@');
+        const contactField = isEmail ? 'email' : 'phoneNumber';
+        
+        // Check if user already exists with this contact info
+        let user = await this.db.user.findFirst({
+            where: { phoneNumber: contactInfo }
+        });
+        
+        // If user doesn't exist, create a temporary account
+        if (!user) {
+            // Generate a random password for temporary accounts
+            const tempPassword = Math.random().toString(36).slice(-8);
+            
+            user = await this.db.user.create({
+                data: {
+                    firstName,
+                    lastName,
+                    phoneNumber: contactInfo, // Using phoneNumber as the unique identifier
+                    password: tempPassword, // In a real system, this should be hashed
+                    temporaryAccount: true,
+                    country: 'Unknown', // Default values
+                    language: 'en',
+                    sex: 'other',
+                    role: 'Patient', // Default role
+                }
+            });
+        }
+        
+        // Now add them as a participant
+        const magicLink = `${process.env.FRONTEND_URL || 'http://localhost:4200'}/join/${consultationId}/${uuidv4()}`;
+        
+        const participant = await this.db.participant.upsert({
+            where: { 
+                consultationId_userId: { consultationId, userId: user.id } 
+            },
+            create: { 
+                consultationId, 
+                userId: user.id, 
+                role, 
+                notes, 
+                magicLink,
+                isActive: false
+            },
+            update: { 
+                role, 
+                notes,
+                magicLink 
+            },
+        });
+        
+        // In a real implementation, this would send an email or SMS
+        // with the magic link to the participant
+        console.log(`Invitation link for ${firstName}: ${magicLink}`);
+        
+        return {
+            participant,
+            user,
+            magicLink,
+            isNewUser: !user
+        };
     }
 }

--- a/patient/src/app/app.component.ts
+++ b/patient/src/app/app.component.ts
@@ -1,10 +1,18 @@
 import { Component } from '@angular/core';
 import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { ToastComponent } from './components/toast/toast.component';
 
 @Component({
   selector: 'app-root',
-  templateUrl: 'app.component.html',
-  imports: [IonApp, IonRouterOutlet],
+  template: `
+    <ion-app>
+      <app-toast></app-toast>
+      <ion-router-outlet></ion-router-outlet>
+    </ion-app>
+  `,
+  styleUrls: ['app.component.scss'],
+  standalone: true,
+  imports: [IonApp, IonRouterOutlet, ToastComponent],
 })
 export class AppComponent {
   constructor() {}

--- a/patient/src/app/app.routes.ts
+++ b/patient/src/app/app.routes.ts
@@ -1,8 +1,13 @@
 import { Routes } from '@angular/router';
+import { ToastTestComponent } from './components/toast-test/toast-test.component';
 
 export const routes: Routes = [
   {
     path: '',
     loadChildren: () => import('./tabs/tabs.routes').then((m) => m.routes),
   },
+  {
+    path: 'toast-demo',
+    component: ToastTestComponent
+  }
 ];

--- a/patient/src/app/components/toast-test/toast-test.component.ts
+++ b/patient/src/app/components/toast-test/toast-test.component.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-toast-test',
+  standalone: true,
+  imports: [CommonModule, IonicModule],
+  template: `
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>
+          Toast Notification Demo
+        </ion-title>
+      </ion-toolbar>
+    </ion-header>
+    
+    <ion-content class="ion-padding">
+      <h2>Toast Notification Examples</h2>
+      
+      <div style="display: flex; flex-wrap: wrap; gap: 10px; margin: 20px 0;">
+        <ion-button (click)="showSuccess()">Show Success</ion-button>
+        <ion-button color="danger" (click)="showError()">Show Error</ion-button>
+        <ion-button color="warning" (click)="showWarning()">Show Warning</ion-button>
+      </div>
+    </ion-content>
+  `
+})
+export class ToastTestComponent {
+  constructor(private toastService: ToastService) {}
+
+  showSuccess() {
+    this.toastService.show('Operation completed successfully', 'success');
+  }
+
+  showError() {
+    this.toastService.show('An error occurred', 'error');
+  }
+
+  showWarning() {
+    this.toastService.show('Please review before proceeding', 'warning');
+  }
+} 

--- a/patient/src/app/components/toast/toast.component.ts
+++ b/patient/src/app/components/toast/toast.component.ts
@@ -1,0 +1,82 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService } from '../../services/toast.service';
+import { IonicModule } from '@ionic/angular';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  imports: [CommonModule, IonicModule],
+  template: `
+    <div *ngIf="toastService.toast$ | async as toast" class="toast" [ngClass]="toast.type">
+      <div class="toast-content">
+        <ion-icon *ngIf="toast.type === 'success'" name="checkmark-circle"></ion-icon>
+        <ion-icon *ngIf="toast.type === 'error'" name="close-circle"></ion-icon>
+        <ion-icon *ngIf="toast.type === 'warning'" name="warning"></ion-icon>
+        <span class="toast-message">{{ toast.message }}</span>
+      </div>
+      <ion-button fill="clear" size="small" class="toast-close" (click)="toastService.hide()">
+        <ion-icon name="close"></ion-icon>
+      </ion-button>
+    </div>
+  `,
+  styles: [`
+    .toast {
+      position: fixed;
+      bottom: 2rem;
+      left: 50%;
+      transform: translateX(-50%);
+      min-width: 250px;
+      max-width: 80%;
+      padding: 1rem;
+      border-radius: 8px;
+      color: #fff;
+      font-size: 1rem;
+      z-index: 1000;
+      opacity: 0.95;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+      transition: all 0.3s;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      animation: slide-in 0.3s ease-out;
+    }
+    
+    .toast-content {
+      display: flex;
+      align-items: center;
+      flex-grow: 1;
+      gap: 10px;
+    }
+    
+    .toast-message {
+      font-weight: 500;
+    }
+    
+    .toast-close {
+      --padding-start: 0;
+      --padding-end: 0;
+      height: 20px;
+      color: inherit;
+      margin: 0;
+    }
+    
+    .toast.success { background: var(--ion-color-success); }
+    .toast.error { background: var(--ion-color-danger); }
+    .toast.warning { background: var(--ion-color-warning); color: var(--ion-color-dark); }
+    
+    @keyframes slide-in {
+      from {
+        transform: translate(-50%, 100%);
+        opacity: 0;
+      }
+      to {
+        transform: translate(-50%, 0);
+        opacity: 0.95;
+      }
+    }
+  `]
+})
+export class ToastComponent {
+  constructor(public toastService: ToastService) {}
+} 

--- a/patient/src/app/interceptors/toast.interceptor.ts
+++ b/patient/src/app/interceptors/toast.interceptor.ts
@@ -32,4 +32,4 @@ export class ToastInterceptor implements HttpInterceptor {
       })
     );
   }
-}
+} 

--- a/patient/src/app/services/toast.service.ts
+++ b/patient/src/app/services/toast.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export type ToastType = 'success' | 'error' | 'warning';
+
+export interface ToastMessage {
+  message: string;
+  type: ToastType;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private toastSubject = new BehaviorSubject<ToastMessage | null>(null);
+
+  toast$ = this.toastSubject.asObservable();
+
+  show(message: string, type: ToastType = 'success') {
+    this.toastSubject.next({ message, type });
+    setTimeout(() => this.hide(), 3000); // auto-hide after 3s
+  }
+
+  hide() {
+    this.toastSubject.next(null);
+  }
+} 

--- a/patient/src/main.ts
+++ b/patient/src/main.ts
@@ -1,6 +1,8 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { ToastInterceptor } from './app/interceptors/toast.interceptor';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
@@ -10,5 +12,7 @@ bootstrapApplication(AppComponent, {
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
+    provideHttpClient(withInterceptorsFromDi()),
+    { provide: ToastInterceptor, useClass: ToastInterceptor }
   ],
 });

--- a/practitioner/src/app/app.component.ts
+++ b/practitioner/src/app/app.component.ts
@@ -1,11 +1,15 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { ToastComponent } from './components/toast/toast.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
-  templateUrl: './app.component.html',
+  imports: [RouterOutlet, ToastComponent],
+  template: `
+    <app-toast></app-toast>
+    <router-outlet></router-outlet>
+  `,
   styleUrl: './app.component.scss'
 })
 export class AppComponent {

--- a/practitioner/src/app/app.config.ts
+++ b/practitioner/src/app/app.config.ts
@@ -1,8 +1,15 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { ToastInterceptor } from './interceptors/toast.interceptor';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }), 
+    provideRouter(routes),
+    provideHttpClient(withInterceptorsFromDi()),
+    { provide: ToastInterceptor, useClass: ToastInterceptor }
+  ]
 };

--- a/practitioner/src/app/app.routes.ts
+++ b/practitioner/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import type { Routes } from '@angular/router';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { AppComponent } from './app.component';
 import { RoutePaths } from './constants/route-paths.enum';
+import { ToastTestComponent } from './components/toast-test/toast-test.component';
 
 export const routes: Routes = [
   {
@@ -10,6 +11,7 @@ export const routes: Routes = [
     children: [
       { path: '', redirectTo: RoutePaths.Dashboard, pathMatch: 'full' },
       { path: RoutePaths.Dashboard, component: DashboardComponent },
+      { path: 'toast-demo', component: ToastTestComponent },
     ],
   },
 ];

--- a/practitioner/src/app/components/toast-test/toast-test.component.ts
+++ b/practitioner/src/app/components/toast-test/toast-test.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-toast-test',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div style="padding: 20px;">
+      <h2>Toast Notification Demo</h2>
+      
+      <div style="display: flex; gap: 10px; margin: 20px 0;">
+        <button style="padding: 8px 16px;" (click)="showSuccess()">Show Success</button>
+        <button style="padding: 8px 16px;" (click)="showError()">Show Error</button>
+        <button style="padding: 8px 16px;" (click)="showWarning()">Show Warning</button>
+      </div>
+    </div>
+  `
+})
+export class ToastTestComponent {
+  constructor(private toastService: ToastService) {}
+
+  showSuccess() {
+    this.toastService.show('Operation completed successfully', 'success');
+  }
+
+  showError() {
+    this.toastService.show('An error occurred', 'error');
+  }
+
+  showWarning() {
+    this.toastService.show('Please review before proceeding', 'warning');
+  }
+} 

--- a/practitioner/src/app/components/toast/toast.component.ts
+++ b/practitioner/src/app/components/toast/toast.component.ts
@@ -1,0 +1,92 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div *ngIf="toastService.toast$ | async as toast" class="toast" [ngClass]="toast.type">
+      <div class="toast-content">
+        <span class="toast-icon">
+          <i *ngIf="toast.type === 'success'" class="fa fa-check-circle"></i>
+          <i *ngIf="toast.type === 'error'" class="fa fa-times-circle"></i>
+          <i *ngIf="toast.type === 'warning'" class="fa fa-exclamation-triangle"></i>
+        </span>
+        <span class="toast-message">{{ toast.message }}</span>
+      </div>
+      <button class="toast-close" (click)="toastService.hide()">×</button>
+    </div>
+  `,
+  styles: [`
+    .toast {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      min-width: 250px;
+      max-width: 400px;
+      padding: 1rem;
+      border-radius: 8px;
+      color: #fff;
+      font-size: 1rem;
+      z-index: 1000;
+      opacity: 0.95;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+      transition: all 0.3s;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      animation: slide-in 0.3s ease-out;
+    }
+    
+    .toast-content {
+      display: flex;
+      align-items: center;
+      flex-grow: 1;
+    }
+    
+    .toast-icon {
+      margin-right: 10px;
+    }
+    
+    .toast-message {
+      font-weight: 500;
+    }
+    
+    .toast-close {
+      background: none;
+      border: none;
+      color: inherit;
+      font-size: 1.5rem;
+      cursor: pointer;
+      opacity: 0.7;
+      transition: opacity 0.2s;
+      padding: 0;
+      margin-left: 10px;
+      line-height: 1;
+    }
+    
+    .toast-close:hover {
+      opacity: 1;
+    }
+    
+    .toast.success { background: #43a047; }
+    .toast.error { background: #e53935; }
+    .toast.warning { background: #ffa000; color: #333; }
+    
+    @keyframes slide-in {
+      from {
+        transform: translateX(100%);
+        opacity: 0;
+      }
+      to {
+        transform: translateX(0);
+        opacity: 0.95;
+      }
+    }
+  `]
+})
+export class ToastComponent {
+  constructor(public toastService: ToastService) {}
+} 

--- a/practitioner/src/app/interceptors/toast.interceptor.ts
+++ b/practitioner/src/app/interceptors/toast.interceptor.ts
@@ -32,4 +32,4 @@ export class ToastInterceptor implements HttpInterceptor {
       })
     );
   }
-}
+} 

--- a/practitioner/src/app/profile/profile.component.ts
+++ b/practitioner/src/app/profile/profile.component.ts
@@ -1,0 +1,138 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { UserService } from '../services/user.service';
+import { MessageService, User } from '../models/user.model';
+import { ToastService } from '../services/toast.service';
+
+@Component({
+  selector: 'app-profile',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSlideToggleModule,
+    MatRadioModule,
+    MatButtonModule,
+    MatSelectModule
+  ],
+  templateUrl: './profile.component.html',
+  styleUrls: ['./profile.component.scss']
+})
+export class ProfileComponent implements OnInit {
+  profileForm!: FormGroup;
+  notificationForm!: FormGroup;
+  user: User | null = null;
+  messageServiceOptions = Object.values(MessageService).filter(
+    val => val === MessageService.SMS || val === MessageService.WHATSAPP
+  );
+  
+  // Temporary user ID - should be replaced with actual auth user ID
+  userId = 1;
+
+  constructor(
+    private fb: FormBuilder,
+    private userService: UserService,
+    private toastService: ToastService
+  ) {}
+
+  ngOnInit(): void {
+    this.initForms();
+    this.loadUserProfile();
+  }
+
+  initForms(): void {
+    this.profileForm = this.fb.group({
+      firstName: ['', Validators.required],
+      lastName: ['', Validators.required],
+      phoneNumber: ['', Validators.required],
+      country: ['', Validators.required],
+      language: ['', Validators.required]
+    });
+
+    this.notificationForm = this.fb.group({
+      notificationsEnabled: [false],
+      notificationPhoneNumber: ['', [
+        Validators.pattern(/^\+?[0-9]{10,15}$/) // Basic international phone validation
+      ]],
+      preferredNotificationChannel: [null]
+    });
+
+    // Add conditional validator for notification phone and channel
+    this.notificationForm.get('notificationsEnabled')?.valueChanges.subscribe(enabled => {
+      const phoneControl = this.notificationForm.get('notificationPhoneNumber');
+      const channelControl = this.notificationForm.get('preferredNotificationChannel');
+      
+      if (enabled) {
+        phoneControl?.setValidators([Validators.required, Validators.pattern(/^\+?[0-9]{10,15}$/)]);
+        channelControl?.setValidators([Validators.required]);
+      } else {
+        phoneControl?.clearValidators();
+        channelControl?.clearValidators();
+      }
+      
+      phoneControl?.updateValueAndValidity();
+      channelControl?.updateValueAndValidity();
+    });
+  }
+
+  loadUserProfile(): void {
+    this.userService.getUserProfile(this.userId).subscribe({
+      next: (response) => {
+        this.user = response.data;
+        if (this.user) {
+          this.updateForms(this.user);
+        }
+      },
+      error: (error) => {
+        this.toastService.show('Failed to load user profile. Please try again.', 'error');
+        console.error('Error loading user profile:', error);
+      }
+    });
+  }
+
+  updateForms(user: User): void {
+    this.profileForm.patchValue({
+      firstName: user.firstName,
+      lastName: user.lastName,
+      phoneNumber: user.phoneNumber,
+      country: user.country,
+      language: user.language
+    });
+
+    this.notificationForm.patchValue({
+      notificationsEnabled: user.notificationsEnabled || false,
+      notificationPhoneNumber: user.notificationPhoneNumber || user.phoneNumber,
+      preferredNotificationChannel: user.preferredNotificationChannel || null
+    });
+  }
+
+  saveNotificationPreferences(): void {
+    if (this.notificationForm.invalid) {
+      return;
+    }
+
+    const preferences = this.notificationForm.value;
+    this.userService.updateNotificationPreferences(this.userId, preferences).subscribe({
+      next: (response) => {
+        this.toastService.show('Notification preferences updated successfully', 'success');
+      },
+      error: (error) => {
+        this.toastService.show('Failed to update notification preferences. Please try again.', 'error');
+        console.error('Error updating notification preferences:', error);
+      }
+    });
+  }
+} 

--- a/practitioner/src/app/services/toast.service.ts
+++ b/practitioner/src/app/services/toast.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export type ToastType = 'success' | 'error' | 'warning';
+
+export interface ToastMessage {
+  message: string;
+  type: ToastType;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private toastSubject = new BehaviorSubject<ToastMessage | null>(null);
+
+  toast$ = this.toastSubject.asObservable();
+
+  show(message: string, type: ToastType = 'success') {
+    this.toastSubject.next({ message, type });
+    setTimeout(() => this.hide(), 3000); // auto-hide after 3s
+  }
+
+  hide() {
+    this.toastSubject.next(null);
+  }
+} 


### PR DESCRIPTION
## Description
This PR implements the feature to add experts and guests to consultations, both during pre-invite and live consultations, as specified in issue #24.

## Changes
- Added `ParticipantRole` enum to distinguish between PATIENT, PRACTITIONER, EXPERT, and GUEST
- Updated Participant model to include role, notes, and magic link
- Added endpoints for adding existing users as participants
- Added endpoints for inviting external participants via email/phone
- Implemented WebSocket support for real-time participant management
- Added automatic creation of temporary user accounts for external participants

## Endpoints Added
- `POST /consultation/:id/participants` - Add a single participant
- `POST /consultation/:id/participants/batch` - Add multiple participants
- `POST /consultation/:id/participants/invite` - Invite external participant
- `POST /consultation/:id/participants/invite/batch` - Invite multiple external participants
- `POST /consultation/:id/join/participant` - For experts/guests to join

## WebSocket Events
- `add_participant` - Add existing user to consultation
- `invite_external_participant` - Invite external participant
- Event notifications for when participants join, leave, or get invited

## Related Issue
Fixes #24