### PR TITLE
Add messaging utility endpoint to check SMS and WhatsApp support

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { ConsultationModule } from './consultation/consultation.module';
+import { MessagingModule } from './messaging/messaging.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { ConsultationModule } from './consultation/consultation.module';
     AuthModule,
     UserModule,
     ConsultationModule,
+    MessagingModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/messaging/messaging.controller.ts
+++ b/backend/src/messaging/messaging.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Query, BadRequestException } from '@nestjs/common';
+import { MessagingService } from './messaging.service';
+import { MessageSupportResponse } from './messaging.types';
+
+@Controller('messaging')
+export class MessagingController {
+  constructor(private readonly messagingService: MessagingService) {}
+
+  /**
+   * Check if a phone number can receive messages via SMS and/or WhatsApp
+   * based on the current configuration in SMS_Providers
+   * 
+   * @param phoneNumber The phone number to check
+   * @returns Support information for SMS and WhatsApp
+   */
+  @Get('check-support')
+  async checkSupport(@Query('phoneNumber') phoneNumber: string): Promise<{success: boolean} & MessageSupportResponse> {
+    if (!phoneNumber) {
+      throw new BadRequestException('Phone number is required');
+    }
+    
+    try {
+      const supportInfo = await this.messagingService.checkMessageSupport(phoneNumber);
+      return {
+        success: true,
+        ...supportInfo
+      };
+    } catch (error) {
+      throw new BadRequestException('Failed to check message support: ' + error.message);
+    }
+  }
+} 

--- a/backend/src/messaging/messaging.module.ts
+++ b/backend/src/messaging/messaging.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MessagingController } from './messaging.controller';
+import { MessagingService } from './messaging.service';
+import { DatabaseModule } from '../database/database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [MessagingController],
+  providers: [MessagingService],
+  exports: [MessagingService],
+})
+export class MessagingModule {} 

--- a/backend/src/messaging/messaging.service.ts
+++ b/backend/src/messaging/messaging.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { MessageSupportResponse, ProviderSupport } from './messaging.types';
+
+@Injectable()
+export class MessagingService {
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Check if a phone number can receive SMS and/or WhatsApp messages
+   * based on the configured SMS_Providers
+   * 
+   * @param phoneNumber The phone number to check
+   * @returns Support information for SMS and WhatsApp
+   */
+  async checkMessageSupport(phoneNumber: string): Promise<MessageSupportResponse> {
+    // Clean the phone number (remove spaces, dashes, etc.)
+    const cleanNumber = this.cleanPhoneNumber(phoneNumber);
+    console.log('Checking support for phone number:', phoneNumber);
+    console.log('Cleaned phone number:', cleanNumber);
+    
+    // Get all active providers from the database - select only needed fields to avoid BigInt serialization issues
+    const allProviders = await this.db.sMS_Providers.findMany({
+      where: { isDisabled: false },
+      orderBy: { order: 'asc' }, 
+      select: {
+        id: true,
+        provider: true,
+        prefix: true,
+        order: true,
+        isWhatsapp: true,
+        isDisabled: true
+        // Exclude createdAt and updatedAt which are BigInt
+      }
+    });
+    
+    console.log('Found providers:', allProviders);
+    
+    // Find matching providers based on prefix
+    const matchingProviders = allProviders.filter(provider => {
+      console.log(`Comparing: "${cleanNumber}" starts with "${provider.prefix}"?`);
+      // Handle prefixes with/without + character for more robust matching
+      const providerPrefix = provider.prefix.replace(/^\+/, '');
+      const numberToCheck = cleanNumber.replace(/^\+/, '');
+      const isMatch = numberToCheck.startsWith(providerPrefix);
+      console.log(`Result: ${isMatch} (${numberToCheck} starts with ${providerPrefix})`);
+      return isMatch;
+    });
+    
+    console.log('Matching providers:', matchingProviders);
+    
+    // Separate SMS and WhatsApp providers
+    const smsProviders: ProviderSupport[] = matchingProviders
+      .filter(provider => !provider.isWhatsapp)
+      .map(p => ({ provider: p.provider, order: p.order }));
+      
+    const whatsappProviders: ProviderSupport[] = matchingProviders
+      .filter(provider => provider.isWhatsapp)
+      .map(p => ({ provider: p.provider, order: p.order }));
+    
+    console.log('SMS Providers:', smsProviders);
+    console.log('WhatsApp Providers:', whatsappProviders);
+    
+    return {
+      canSendSMS: smsProviders.length > 0,
+      canSendWhatsapp: whatsappProviders.length > 0,
+      smsProviders,
+      whatsappProviders,
+    };
+  }
+  
+  /**
+   * Clean a phone number by removing non-digit characters
+   * except for the leading + sign
+   */
+  private cleanPhoneNumber(phoneNumber: string): string {
+    // First trim any whitespace
+    let cleanedNumber = phoneNumber.trim();
+    // Check if it starts with +
+    const hasPlus = cleanedNumber.startsWith('+');
+    // Remove all non-digit characters
+    cleanedNumber = cleanedNumber.replace(/\D/g, '');
+    // Add back the + if it was there
+    if (hasPlus) {
+      cleanedNumber = '+' + cleanedNumber;
+    }
+    return cleanedNumber;
+  }
+} 

--- a/backend/src/messaging/messaging.types.ts
+++ b/backend/src/messaging/messaging.types.ts
@@ -1,0 +1,11 @@
+export interface ProviderSupport {
+  provider: string;
+  order: number;
+}
+
+export interface MessageSupportResponse {
+  canSendSMS: boolean;
+  canSendWhatsapp: boolean;
+  smsProviders: ProviderSupport[];
+  whatsappProviders: ProviderSupport[];
+} 


### PR DESCRIPTION
# Add endpoint to check SMS/WhatsApp support for a given phone number

This PR resolves issue #18 by implementing a new backend utility endpoint to verify messaging support for phone numbers.

## Features Implemented

- Created a new endpoint: `GET /messaging/check-support`
- Added phone number validation and parsing
- Implemented provider matching based on number prefixes
- Added support detection for both SMS and WhatsApp channels
- Returns detailed provider information with routing priority

## Implementation Details

- Created a new `MessagingModule` with controller and service
- Added separate type definitions for better code organization
- Implemented phone number cleaning to handle various formats
- Added proper error handling for invalid requests
- Optimized database queries to avoid BigInt serialization issues

## API Endpoint Details

### `GET /messaging/check-support`

**Query Parameters:**
- `phoneNumber` (required): The phone number to check (e.g., +1234567890)

**Response:**
```json
{
  "success": true,
  "canSendSMS": true,
  "canSendWhatsapp": false,
  "smsProviders": [
    {
      "provider": "Twilio-SMS",
      "order": 1
    }
  ],
  "whatsappProviders": []
}
```

## How to Test

1. Ensure your database has SMS_Providers entries with different prefixes
2. Start the backend server
3. Test with various phone numbers:
   - US/Canada: `+1234567890` (Should show SMS support)
   - India: `+91234567890` (Should show WhatsApp support)
   - UK: `+44234567890` (Should show SMS support)
   - Unsupported: `+65234567890` (Should show no support)

## Frontend Integration

This endpoint enables the frontend to:
- Pre-validate message delivery methods
- Show appropriate UI options based on available channels
- Display warnings when certain messaging methods aren't available
- Route messages through the appropriate provider based on priority

Closes #18