### PR TITLE
feat(test-call): Add Test Call page for microphone and camera verification

### DIFF
--- a/practitioner/src/app/app.routes.ts
+++ b/practitioner/src/app/app.routes.ts
@@ -3,12 +3,14 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { AppComponent } from './app.component';
 import { RoutePaths } from './constants/route-paths.enum';
 
+import { TestCallComponent } from './test-call/test-call.component';
 export const routes: Routes = [
   {
     path: '',
     component: AppComponent,
     children: [
       { path: '', redirectTo: RoutePaths.Dashboard, pathMatch: 'full' },
+      { path: RoutePaths.Test, component: TestCallComponent },
       { path: RoutePaths.Dashboard, component: DashboardComponent },
     ],
   },

--- a/practitioner/src/app/components/device-selection/device-selection.component.html
+++ b/practitioner/src/app/components/device-selection/device-selection.component.html
@@ -1,0 +1,7 @@
+<div class="device-selection">
+    <select [value]="selectedDeviceId" (change)="onChange($event)">
+        <option *ngFor="let device of devices" [value]="device.deviceId">
+            {{ device.label || 'Unknown Device' }}
+        </option>
+    </select>
+</div>

--- a/practitioner/src/app/components/device-selection/device-selection.component.scss
+++ b/practitioner/src/app/components/device-selection/device-selection.component.scss
@@ -1,0 +1,16 @@
+.device-selection select {
+    padding: 0.5rem;
+    font-size: 1rem;
+}
+:host {
+    display: block;
+    margin-top: 15px;
+}
+
+select {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 14px;
+}

--- a/practitioner/src/app/components/device-selection/device-selection.component.spec.ts
+++ b/practitioner/src/app/components/device-selection/device-selection.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeviceSelectionComponent } from './device-selection.component';
+
+describe('DeviceSelectionComponent', () => {
+  let component: DeviceSelectionComponent;
+  let fixture: ComponentFixture<DeviceSelectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeviceSelectionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeviceSelectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/practitioner/src/app/components/device-selection/device-selection.component.ts
+++ b/practitioner/src/app/components/device-selection/device-selection.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface MediaDevice {
+  deviceId: string;
+  label?: string;
+}
+
+@Component({
+  selector: 'app-device-selection',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './device-selection.component.html',
+  styleUrls: ['./device-selection.component.scss'],
+})
+export class DeviceSelectionComponent {
+  @Input() devices: MediaDevice[] = [];
+  @Input() selectedDeviceId?: string;
+  @Output() deviceChange = new EventEmitter<string>();
+
+  onChange(event: Event) {
+    const select = event.target as HTMLSelectElement;
+    this.deviceChange.emit(select.value);
+  }
+}

--- a/practitioner/src/app/components/toast-container/toast-container.component.html
+++ b/practitioner/src/app/components/toast-container/toast-container.component.html
@@ -1,0 +1,1 @@
+<p>toast-container works!</p>

--- a/practitioner/src/app/components/toast-container/toast-container.component.scss
+++ b/practitioner/src/app/components/toast-container/toast-container.component.scss
@@ -1,0 +1,20 @@
+@use './variables' as *; 
+
+.toast-container {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 1000;
+}
+
+.toast {
+    background-color: rgba(0, 0, 0, 0.85);
+    color: #fff;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    font-size: 0.875rem;
+}

--- a/practitioner/src/app/components/toast-container/toast-container.component.spec.ts
+++ b/practitioner/src/app/components/toast-container/toast-container.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ToastContainerComponent } from './toast-container.component';
+
+describe('ToastContainerComponent', () => {
+  let component: ToastContainerComponent;
+  let fixture: ComponentFixture<ToastContainerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ToastContainerComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ToastContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/practitioner/src/app/components/toast-container/toast-container.component.ts
+++ b/practitioner/src/app/components/toast-container/toast-container.component.ts
@@ -1,0 +1,21 @@
+// src/app/components/toast-container/toast-container.component.ts
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService } from '../../services/toast/toast.service';
+
+@Component({
+  selector: 'app-toast-container',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="toast-container">
+      <div class="toast" *ngFor="let msg of toast.messages$ | async">
+        {{ msg }}
+      </div>
+    </div>
+  `,
+  styleUrls: ['./toast-container.component.scss'],
+})
+export class ToastContainerComponent {
+  constructor(public toast: ToastService) {}
+}

--- a/practitioner/src/app/components/typography/typography.component.html
+++ b/practitioner/src/app/components/typography/typography.component.html
@@ -1,0 +1,20 @@
+<ng-container [ngSwitch]="level">
+    <ng-template ngSwitchCase="1">
+        <h1><ng-content></ng-content></h1>
+    </ng-template>
+    <ng-template ngSwitchCase="2">
+        <h2><ng-content></ng-content></h2>
+    </ng-template>
+    <ng-template ngSwitchCase="3">
+        <h3><ng-content></ng-content></h3>
+    </ng-template>
+    <ng-template ngSwitchCase="4">
+        <h4><ng-content></ng-content></h4>
+    </ng-template>
+    <ng-template ngSwitchCase="5">
+        <h5><ng-content></ng-content></h5>
+    </ng-template>
+    <ng-template ngSwitchDefault>
+        <h6><ng-content></ng-content></h6>
+    </ng-template>
+</ng-container>

--- a/practitioner/src/app/components/typography/typography.component.scss
+++ b/practitioner/src/app/components/typography/typography.component.scss
@@ -1,0 +1,46 @@
+@use './variables' as *;
+:host {
+    display: block;
+    margin: 0.5rem 0;
+    font-family: $font-family-base; 
+    color: $color-heading; 
+    line-height: $line-height-base; 
+    font-weight: 500; 
+    letter-spacing: 0.03; 
+    word-spacing: 0.05; 
+    text-transform: none;
+}
+
+:host>h1,
+:host>h2,
+:host>h3,
+:host>h4,
+:host>h5,
+:host>h6 {
+    margin: 0; 
+    padding: 0; 
+}
+
+:host>h1 {
+    font-size: 3rem;
+}
+
+:host>h2 {
+    font-size: 2.5rem;
+}
+
+:host>h3 {
+    font-size: 2rem;
+}
+
+:host>h4 {
+    font-size: 1.75rem;
+}
+
+:host>h5 {
+    font-size: 1.5rem;
+}
+
+:host>h6 {
+    font-size: 1.25rem;
+}

--- a/practitioner/src/app/components/typography/typography.component.spec.ts
+++ b/practitioner/src/app/components/typography/typography.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TypographyComponent } from './typography.component';
+
+describe('TypographyComponent', () => {
+  let component: TypographyComponent;
+  let fixture: ComponentFixture<TypographyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TypographyComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TypographyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/practitioner/src/app/components/typography/typography.component.ts
+++ b/practitioner/src/app/components/typography/typography.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-typography',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './typography.component.html',
+  styleUrls: ['./typography.component.scss'],
+})
+export class TypographyComponent {
+  @Input() level: 1 | 2 | 3 | 4 | 5 | 6 = 2;
+}

--- a/practitioner/src/app/components/ui/button/button.component.scss
+++ b/practitioner/src/app/components/ui/button/button.component.scss
@@ -17,7 +17,7 @@ button,
 }
 
 .primary {
-    background-color: $color-primary;
+    background-color: $button-primary-color;
     color: white;
 
     &:hover {

--- a/practitioner/src/app/services/toast/toast.service.ts
+++ b/practitioner/src/app/services/toast/toast.service.ts
@@ -1,0 +1,19 @@
+// src/app/services/toast.service.ts
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private _messages = new BehaviorSubject<string[]>([]);
+  readonly messages$ = this._messages.asObservable();
+
+  show(message: string, durationMs = 3000) {
+    const current = this._messages.getValue();
+    this._messages.next([...current, message]);
+
+    setTimeout(() => {
+      const after = this._messages.getValue().filter((m) => m !== message);
+      this._messages.next(after);
+    }, durationMs);
+  }
+}

--- a/practitioner/src/app/test-call/test-call.component.html
+++ b/practitioner/src/app/test-call/test-call.component.html
@@ -1,0 +1,31 @@
+<div class="test-call">
+    <div class="test-sections">
+
+        <div class="test-section micro-test">
+            <app-typography [level]="2">MICRO TEST</app-typography>
+
+            <div class="audio-meter-container">
+                <div class="audio-meter">
+                    <div #audioMeter class="meter-fill"></div>
+                </div>
+            </div>
+            <p class="help-text">
+                A properly tuned microphone should put the VU meter in the green center area when speaking.
+            </p>
+
+            <app-device-selection *ngIf="audioInputDevices.length > 1" [devices]="audioInputDevices"
+                [selectedDeviceId]="selectedAudioDeviceId"
+                (deviceChange)="switchAudioInput($event)"></app-device-selection>
+        </div>
+
+        <div class="test-section camera-test">
+            <app-typography [level]="2">CAMERA TEST</app-typography>
+            <div class="video-container">
+                <video #videoPreview autoplay playsinline muted></video>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<app-toast-container></app-toast-container>

--- a/practitioner/src/app/test-call/test-call.component.scss
+++ b/practitioner/src/app/test-call/test-call.component.scss
@@ -1,0 +1,78 @@
+@use './variables' as *;
+
+.test-call {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+    background-color: $color-background-card;
+
+    .test-sections {
+        display: flex;
+        width: 100%;
+        max-width: 1200px;
+        gap: 20px;
+
+        @media (max-width: 768px) {
+            flex-direction: column;
+        }
+    }
+
+    .test-section {
+        flex: 1;
+        padding: 20px;
+        border: 1px solid $color-border;
+        border-radius: 4px;
+    }
+
+    .micro-test {
+        .audio-meter-container {
+            width: 100%;
+            margin-bottom: 15px;
+
+            .audio-meter {
+                width: 100%;
+                height: 10px;
+                background-color: $color-surface;
+                border-radius: 5px;
+                overflow: hidden;
+                border: 1px solid $color-border-light;
+
+                .meter-fill {
+                    height: 100%;
+                    width: 0;
+                    background-color: $color-success;
+                    transition: width 0.1s linear;
+                }
+            }
+        }
+
+        .help-text {
+            color: $color-primary;
+            font-size: 14px;
+            margin-bottom: 20px;
+            line-height: 1.5;
+        }
+        app-typography {
+            display: block; // ensure it behaves like a heading
+            margin-bottom: 20px;
+            color: $color-heading;
+            font-size: 20px; // same size as before
+            font-weight: bold;     
+        }
+    }
+
+    .camera-test {
+        .video-container {
+            width: 100%;
+
+            video {
+                width: 100%;
+                border: 1px solid $color-border-light;
+                border-radius: 4px;
+                background-color: $color-empty-state-bg;
+                min-height: 240px;
+            }
+        }
+    }
+}

--- a/practitioner/src/app/test-call/test-call.component.spec.ts
+++ b/practitioner/src/app/test-call/test-call.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TestCallComponent } from './test-call.component';
+
+describe('TestCallComponent', () => {
+  let component: TestCallComponent;
+  let fixture: ComponentFixture<TestCallComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestCallComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TestCallComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/practitioner/src/app/test-call/test-call.component.ts
+++ b/practitioner/src/app/test-call/test-call.component.ts
@@ -1,0 +1,135 @@
+import {
+  Component,
+  OnInit,
+  AfterViewInit,
+  ViewChild,
+  ElementRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { DeviceSelectionComponent } from '../components/device-selection/device-selection.component';
+import { TypographyComponent } from '../components/typography/typography.component';
+import { ToastContainerComponent } from '../components/toast-container/toast-container.component';
+import { ToastService } from '../services/toast/toast.service';
+
+@Component({
+  selector: 'app-test-call',
+  standalone: true,
+  imports: [
+    CommonModule,
+    DeviceSelectionComponent,
+    TypographyComponent,
+    ToastContainerComponent,
+  ],
+  templateUrl: './test-call.component.html',
+  styleUrls: ['./test-call.component.scss'],
+})
+export class TestCallComponent implements OnInit, AfterViewInit {
+  @ViewChild('videoPreview', { static: false })
+  videoPreview!: ElementRef<HTMLVideoElement>;
+  @ViewChild('audioMeter', { static: false })
+  audioMeter!: ElementRef<HTMLDivElement>;
+
+  audioInputDevices: MediaDeviceInfo[] = [];
+  selectedAudioDeviceId: string | undefined;
+
+  audioContext?: AudioContext;
+  analyser?: AnalyserNode;
+  microphoneStream?: MediaStreamAudioSourceNode;
+  mediaStream?: MediaStream;
+  constructor(private toast: ToastService) {}
+
+  async ngOnInit(): Promise<void> {
+    await this.enumerateAudioDevices();
+  }
+
+  ngAfterViewInit(): void {
+    this.startMedia();
+  }
+
+  private async startMedia(): Promise<void> {
+    try {
+      const audioConstraints = this.selectedAudioDeviceId
+        ? { deviceId: { exact: this.selectedAudioDeviceId } }
+        : true;
+
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: true,
+        audio: audioConstraints,
+      });
+
+      this.videoPreview.nativeElement.srcObject = this.mediaStream;
+      this.setupAudioAnalyzer();
+    } catch (err) {
+      console.error('Error accessing media devices', err);
+      this.toast.show('⚠️ Cannot access camera/microphone');
+    }
+  }
+
+  private setupAudioAnalyzer(): void {
+    if (!this.mediaStream) {
+      return;
+    }
+
+    this.audioContext = new AudioContext();
+    this.microphoneStream = this.audioContext.createMediaStreamSource(
+      this.mediaStream
+    );
+    this.analyser = this.audioContext.createAnalyser();
+    this.analyser.fftSize = 256;
+    this.microphoneStream.connect(this.analyser);
+    this.updateAudioMeter();
+  }
+
+  private updateAudioMeter(): void {
+    if (!this.analyser) {
+      return;
+    }
+    const dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+    this.analyser.getByteFrequencyData(dataArray);
+    const avg =
+      dataArray.reduce((sum, value) => sum + value, 0) / dataArray.length;
+
+    this.audioMeter.nativeElement.style.width = (avg / 255) * 100 + '%';
+    requestAnimationFrame(() => this.updateAudioMeter());
+  }
+
+  private async enumerateAudioDevices(): Promise<void> {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      this.audioInputDevices = devices.filter((d) => d.kind === 'audioinput');
+
+      // default to first device
+      if (this.audioInputDevices.length) {
+        this.selectedAudioDeviceId = this.audioInputDevices[0].deviceId;
+      }
+    } catch (err) {
+      console.error('Error enumerating devices', err);
+    }
+  }
+
+  async switchAudioInput(deviceId: string): Promise<void> {
+    this.selectedAudioDeviceId = deviceId;
+
+    this.mediaStream?.getAudioTracks().forEach((t) => t.stop());
+
+    try {
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: true,
+        audio: { deviceId: { exact: deviceId } },
+      });
+      this.videoPreview.nativeElement.srcObject = this.mediaStream;
+
+      if (this.audioContext && this.analyser) {
+        this.microphoneStream?.disconnect();
+        this.microphoneStream = this.audioContext.createMediaStreamSource(
+          this.mediaStream
+        );
+        this.microphoneStream.connect(this.analyser);
+      }
+    } catch (err) {
+      console.error('Error switching audio device', err);
+      this.toast.show('⚠️ Error switching audio device');
+    }
+  }
+}

--- a/practitioner/src/styles/variables/_buttons.scss
+++ b/practitioner/src/styles/variables/_buttons.scss
@@ -1,4 +1,4 @@
-$color-primary: #4169e1;
+$button-primary-color: #4CAF50;
 $color-primary-hover: #3a5fcd;
 $color-secondary-bg: #eeeeee;
 $color-secondary-hover: #dddddd;

--- a/practitioner/src/styles/variables/_colors.scss
+++ b/practitioner/src/styles/variables/_colors.scss
@@ -6,3 +6,8 @@ $color-description: #666666;
 $color-empty-state-bg: #f9f9f9;
 $color-empty-state-text: #888888;
 $color-border-bottom: #f0f0f0;
+$color-primary: #2196F3;
+$color-success: #4CAF50;
+$color-border: #e0e0e0;
+$color-border-light: #ddd;
+$color-surface: #eee;


### PR DESCRIPTION
### Description

This PR adds a **Test Call** page for practitioners to verify their microphone and camera setup before entering real consultations.

### Features Implemented
- Added "Test Call" page.
- On load: Requests camera and microphone access.
- Shows:
  - Live camera preview
  - Real-time microphone input volume meter
-  Device selection logic implemented where supported

### Linked Issue
Closes #37 

### Testing Steps
- Visit `/test-call` after login
- Allow permissions
- Speak and check mic input level
- Switch mic if needed

### Screenshot
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/161a461a-244f-4c82-8bb4-ebe0ebc722a7" />
