### PR TITLE
feat(consultation): implement WebSocket gateway and real-time waiting room flow

### DIFF
--- a/backend/src/auth/guards/auth.guard.ts
+++ b/backend/src/auth/guards/auth.guard.ts
@@ -2,7 +2,6 @@
 
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { Request } from 'express';
 import { HttpExceptionHelper } from 'src/common/helpers/execption/http-exception.helper';
 import { ExtendedRequest } from 'src/types/request';
 import { UserService } from 'src/user/user.service';

--- a/backend/src/auth/guards/roles.guard.ts
+++ b/backend/src/auth/guards/roles.guard.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   CanActivate,
   ExecutionContext,
-  ForbiddenException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY } from 'src/common/decorators/roles.decorator';

--- a/backend/src/consultation/consultation.gateway.ts
+++ b/backend/src/consultation/consultation.gateway.ts
@@ -3,6 +3,9 @@ import {
   OnGatewayDisconnect,
   WebSocketGateway,
   WebSocketServer,
+  SubscribeMessage,
+  MessageBody,
+  ConnectedSocket,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { DatabaseService } from 'src/database/database.service';
@@ -16,18 +19,26 @@ export class ConsultationGateway
   constructor(private readonly databaseService: DatabaseService) {}
 
   /**
-   * When a socket connects, we expect the client to pass
-   * ?consultationId=123&userId=456 in the connection URL.
-   * We join them to the room and mark them active.
+   * On socket connection:
+   * - Expects ?consultationId=123&userId=456&role=PRACTITIONER|PATIENT in the query.
+   * - Joins user to the consultation room.
+   * - If practitioner, also joins their practitioner notification room.
+   * - Marks participant as active in the DB.
    */
   async handleConnection(client: Socket) {
     const cId = Number(client.handshake.query.consultationId);
     const uId = Number(client.handshake.query.userId);
+    const role = client.handshake.query.role as string | undefined;
+
     if (!cId || !uId) return;
 
     client.join(`consultation:${cId}`);
     client.data.consultationId = cId;
     client.data.userId = uId;
+
+    if (role === 'PRACTITIONER') {
+      client.join(`practitioner:${uId}`);
+    }
 
     await this.databaseService.participant.upsert({
       where: { consultationId_userId: { consultationId: cId, userId: uId } },
@@ -37,12 +48,14 @@ export class ConsultationGateway
         isActive: true,
         joinedAt: new Date(),
       },
-      update: { isActive: true },
+      update: { isActive: true, joinedAt: new Date() },
     });
   }
 
   /**
-   * On disconnect, mark them inactive.
+   * On disconnect:
+   * - Marks participant as inactive.
+   * - If all patients have left and status is WAITING, reverts consultation to SCHEDULED.
    */
   async handleDisconnect(client: Socket) {
     const { consultationId, userId } = client.data;
@@ -53,6 +66,7 @@ export class ConsultationGateway
       data: { isActive: false },
     });
 
+    // Check if any active patients remain
     const activePatients = await this.databaseService.participant.findMany({
       where: {
         consultationId,
@@ -65,11 +79,32 @@ export class ConsultationGateway
       where: { id: consultationId },
     });
 
-    if (activePatients.length === 0 && consultation?.status == 'WAITING') {
+    if (activePatients.length === 0 && consultation?.status === 'WAITING') {
       await this.databaseService.consultation.update({
         where: { id: consultationId },
         data: { status: 'SCHEDULED' },
       });
     }
+  }
+
+  /**
+   * Practitioner can explicitly admit a patient (optional real-time event).
+   */
+  @SubscribeMessage('admit_patient')
+  async handleAdmitPatient(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: { consultationId: number },
+  ) {
+    const { consultationId } = data;
+    await this.databaseService.consultation.update({
+      where: { id: consultationId },
+      data: { status: 'ACTIVE' },
+    });
+    this.server
+      .to(`consultation:${consultationId}`)
+      .emit('consultation_status', {
+        status: 'ACTIVE',
+        initiatedBy: 'PRACTITIONER',
+      });
   }
 }

--- a/backend/src/consultation/consultation.module.ts
+++ b/backend/src/consultation/consultation.module.ts
@@ -2,9 +2,19 @@ import { Module } from '@nestjs/common';
 import { ConsultationService } from './consultation.service';
 import { ConsultationController } from './consultation.controller';
 import { ConsultationGateway } from './consultation.gateway';
+import { DatabaseService } from 'src/database/database.service';
 
 @Module({
-  providers: [ConsultationService, ConsultationGateway],
   controllers: [ConsultationController],
+  providers: [
+    ConsultationService,
+    ConsultationGateway,
+    DatabaseService,
+    {
+      provide: 'CONSULTATION_GATEWAY',
+      useExisting: ConsultationGateway,
+    },
+  ],
+  exports: [ConsultationService],
 })
 export class ConsultationModule {}

--- a/backend/src/consultation/dto/admit-patient.dto.ts
+++ b/backend/src/consultation/dto/admit-patient.dto.ts
@@ -1,0 +1,38 @@
+import { IsInt, IsPositive } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * DTO for admitting a patient into a consultation.
+ */
+export class AdmitPatientDto {
+ @ApiProperty({
+  description: 'The unique identifier of the consultation',
+  example: 123,
+  minimum: 1,
+  type: Number,
+ })
+ @IsInt({ message: 'consultationId must be an integer' })
+ @IsPositive({ message: 'consultationId must be a positive integer' })
+ consultationId: number;
+}
+
+/**
+ * Standardized response DTO for admitting a patient.
+ */
+export class AdmitPatientResponseDto {
+ @ApiProperty({ description: 'Indicates if the operation was successful', example: true })
+ success: boolean;
+
+ @ApiProperty({ description: 'HTTP status code of the response', example: 200 })
+ statusCode: number;
+
+ @ApiProperty({ description: 'Response message', example: 'Patient admitted successfully' })
+ message: string;
+
+ @ApiPropertyOptional({ description: 'The unique identifier of the consultation', example: 123 })
+ consultationId?: number;
+
+ constructor(partial: Partial<AdmitPatientResponseDto>) {
+  Object.assign(this, partial);
+ }
+}

--- a/backend/src/consultation/dto/join-consultation.dto.ts
+++ b/backend/src/consultation/dto/join-consultation.dto.ts
@@ -1,0 +1,42 @@
+import { IsInt, IsPositive } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * DTO for joining a consultation as a patient or practitioner.
+ */
+export class JoinConsultationDto {
+ @ApiProperty({
+  description: 'ID of the user joining the consultation',
+  example: 123,
+  type: Number,
+  minimum: 1,
+ })
+ @IsInt({ message: 'userId must be an integer' })
+ @IsPositive({ message: 'userId must be a positive integer' })
+ userId: number;
+}
+
+/**
+ * Standardized response DTO for joining a consultation.
+ */
+export class JoinConsultationResponseDto {
+ @ApiProperty({ description: 'Indicates if the join was successful', example: true })
+ success: boolean;
+
+ @ApiProperty({ description: 'HTTP status code', example: 200 })
+ statusCode: number;
+
+ @ApiProperty({ description: 'Response message', example: 'Joined consultation successfully' })
+ message: string;
+
+ @ApiPropertyOptional({
+  description: 'ID of the consultation joined',
+  example: 456,
+  type: Number,
+ })
+ consultationId?: number;
+
+ constructor(partial: Partial<JoinConsultationResponseDto>) {
+  Object.assign(this, partial);
+ }
+}

--- a/backend/src/consultation/dto/waiting-room-preview.dto.ts
+++ b/backend/src/consultation/dto/waiting-room-preview.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * DTO for a single waiting room preview entry.
+ */
+export class WaitingRoomPreviewDto {
+ @ApiProperty({ example: 1, description: 'Unique identifier for the waiting room entry' })
+ id!: number;
+
+ @ApiProperty({ example: 'AB', description: 'Initials of the patient' })
+ patientInitials!: string;
+
+ @ApiProperty({ type: String, format: 'date-time', nullable: true, example: '2024-06-01T12:00:00Z', description: 'Time when the patient joined, or null' })
+ joinTime!: Date | null;
+
+ @ApiProperty({ example: 'English', nullable: true, description: 'Preferred language of the patient, or null' })
+ language!: string | null;
+}
+
+/**
+ * Standardized DTO for the waiting room response (list + count).
+ */
+export class WaitingRoomPreviewResponseDto {
+ @ApiProperty({ example: true, description: 'Indicates if the request was successful' })
+ success: boolean;
+
+ @ApiProperty({ example: 200, description: 'HTTP status code' })
+ statusCode: number;
+
+ @ApiProperty({ example: 'Waiting rooms fetched successfully', description: 'Response message' })
+ message: string;
+
+ @ApiProperty({ type: [WaitingRoomPreviewDto], description: 'List of waiting room previews' })
+ waitingRooms: WaitingRoomPreviewDto[];
+
+ @ApiProperty({ example: 10, description: 'Total count of waiting rooms' })
+ totalCount: number;
+
+ constructor(partial: Partial<WaitingRoomPreviewResponseDto>) {
+  Object.assign(this, partial);
+ }
+}

--- a/backend/src/consultation/validation/consultation-id-param.pipe.ts
+++ b/backend/src/consultation/validation/consultation-id-param.pipe.ts
@@ -1,0 +1,20 @@
+import { PipeTransform, Injectable } from '@nestjs/common';
+import { HttpExceptionHelper } from 'src/common/helpers/execption/http-exception.helper';
+
+@Injectable()
+export class ConsultationIdParamPipe implements PipeTransform<string, number> {
+  transform(value: string): number {
+    if (Array.isArray(value)) {
+      throw HttpExceptionHelper.badRequest(
+        'consultationId must be a single value',
+      );
+    }
+    const consultationId = Number(value);
+    if (!consultationId || isNaN(consultationId) || consultationId <= 0) {
+      throw HttpExceptionHelper.badRequest(
+        'consultationId must be a positive integer',
+      );
+    }
+    return consultationId;
+  }
+}

--- a/backend/src/consultation/validation/user-id-param.pipe.ts
+++ b/backend/src/consultation/validation/user-id-param.pipe.ts
@@ -1,0 +1,16 @@
+import { PipeTransform, Injectable } from '@nestjs/common';
+import { HttpExceptionHelper } from 'src/common/helpers/execption/http-exception.helper';
+
+@Injectable()
+export class UserIdParamPipe implements PipeTransform<string, number> {
+  transform(value: string): number {
+    if (Array.isArray(value)) {
+      throw HttpExceptionHelper.badRequest('userId must be a single value');
+    }
+    const userId = Number(value);
+    if (!userId || isNaN(userId) || userId <= 0) {
+      throw HttpExceptionHelper.badRequest('userId must be a positive integer');
+    }
+    return userId;
+  }
+}


### PR DESCRIPTION
## PR Type

- [ ] Bugfix  
- ✔️ Feature  
- [ ] Code style update  
- ✔️ Refactoring ( API modifications)  
- [ ] Build related changes  
- ✔️ Tests Done
- [ ] Release  
- [ ] CI related changes  
- [ ] Other

---

## Description

Implements the "Waiting Room" feature for consultations:

- When a patient joins via magic link:
  - Marks participant as active
  - Consultation status set to `"WAITING"` until practitioner joins
- Practitioner can:
  - Fetch all waiting consultations where they are the owner and the patient has joined but practitioner has not
  - See patient initials, join time, and language in waiting room preview
  - Enter consultations from the waiting room list
- Uses centralized API response DTOs and exception helpers
- Includes comprehensive unit tests and real-time event notifications

---

## Breaking Changes

- [ ] Yes  
- ✔️ No

---

**Ready for review.**
