### PR TITLE
feat: Implemented webhook endpoint to track WhatsApp/SMS delivery status

### DIFF
--- a/backend/prisma/migrations/20250613134515_message_webhook_status/migration.sql
+++ b/backend/prisma/migrations/20250613134515_message_webhook_status/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[uuid]` on the table `Message` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "deliveredAt" TIMESTAMP(3),
+ADD COLUMN     "provider" "MessageService",
+ADD COLUMN     "readAt" TIMESTAMP(3),
+ADD COLUMN     "sentAt" TIMESTAMP(3),
+ADD COLUMN     "status" VARCHAR(50),
+ADD COLUMN     "uuid" VARCHAR(100);
+
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" SERIAL NOT NULL,
+    "messageId" INTEGER NOT NULL,
+    "oldStatus" TEXT NOT NULL,
+    "newStatus" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Message_uuid_key" ON "Message"("uuid");
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "Message"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -179,14 +179,31 @@ model Participant {
 }
 
 model Message {
-  id      Int    @id @default(autoincrement())
-  userId  Int
-  content String @db.Text
+  id             Int             @id @default(autoincrement())
+  userId         Int
+  consultationId Int?
+  content        String          @db.Text
+  status         String?         @db.VarChar(50)
+  provider       MessageService?
+  sentAt         DateTime?
+  deliveredAt    DateTime?
+  readAt         DateTime?
+  uuid           String?         @unique @db.VarChar(100)
 
   // Relations
-  user           User          @relation(fields: [userId], references: [id])
-  consultation   Consultation? @relation(fields: [consultationId], references: [id])
-  consultationId Int?
+  user         User          @relation(fields: [userId], references: [id])
+  consultation Consultation? @relation(fields: [consultationId], references: [id])
+  auditLogs    AuditLog[]
+}
+
+model AuditLog {
+  id        Int      @id @default(autoincrement())
+  messageId Int
+  oldStatus String?
+  newStatus String
+  createdAt DateTime @default(now())
+
+  message Message @relation(fields: [messageId], references: [id])
 }
 
 model Whatsapp_Template {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,8 @@ import { OrganizationModule } from './organization/organization.module';
 import { GroupModule } from './group/group.module';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { MediasoupModule } from './mediasoup/mediasoup.module';
+import { WebhooksController } from './webhooks/webhooks.controller';
+import { WebhooksModule } from './webhooks/webhooks.module';
 
 
 @Module({
@@ -23,9 +25,10 @@ import { MediasoupModule } from './mediasoup/mediasoup.module';
     UserModule,
     OrganizationModule,
     GroupModule,
-    MediasoupModule
+    MediasoupModule,
+    WebhooksModule
   ],
-  controllers: [AppController],
+  controllers: [AppController, WebhooksController],
   providers: [AppService],
 })
 export class AppModule implements NestModule {

--- a/backend/src/webhooks/dto/message-status.dto.ts
+++ b/backend/src/webhooks/dto/message-status.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MessageStatusDto {
+  @ApiProperty({ example: 'message-secret-id' })
+  MessageSid: string;
+
+  @ApiProperty({ example: 'delivered' })
+  MessageStatus: string;
+
+  @ApiProperty({ example: 'SMS', enum: ['SMS', 'EMAIL', 'WHATSAPP', 'MANUALLY'], required: false })
+  Provider?: 'SMS' | 'EMAIL' | 'WHATSAPP' | 'MANUALLY';
+}

--- a/backend/src/webhooks/webhooks.controller.spec.ts
+++ b/backend/src/webhooks/webhooks.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhooksController } from './webhooks.controller';
+
+describe('WebhooksController', () => {
+  let controller: WebhooksController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WebhooksController],
+    }).compile();
+
+    controller = module.get<WebhooksController>(WebhooksController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/webhooks/webhooks.controller.ts
+++ b/backend/src/webhooks/webhooks.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { WebhooksService } from './webhooks.service';
+import { MessageStatusDto } from './dto/message-status.dto';
+
+@Controller('webhooks')
+export class WebhooksController {
+  constructor(private readonly webhooks: WebhooksService) {}
+
+  @Post('message-status')
+  async handleStatusUpdate(@Body() body: MessageStatusDto) {
+    try {
+      await this.webhooks.processStatusUpdate(body);
+      return { success: true };
+    } catch (err) {
+      return {
+        success: false,
+        message: err.message || 'Error processing webhook',
+      };
+    }
+  }
+}

--- a/backend/src/webhooks/webhooks.module.ts
+++ b/backend/src/webhooks/webhooks.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+import { DatabaseService } from '../database/database.service';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [WebhooksController],
+  providers: [WebhooksService, DatabaseService],
+  exports: [WebhooksService],
+})
+export class WebhooksModule {}

--- a/backend/src/webhooks/webhooks.service.spec.ts
+++ b/backend/src/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhooksService } from './webhooks.service';
+
+describe('WebhooksService', () => {
+  let service: WebhooksService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WebhooksService],
+    }).compile();
+
+    service = module.get<WebhooksService>(WebhooksService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/webhooks/webhooks.service.ts
+++ b/backend/src/webhooks/webhooks.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { MessageService } from '@prisma/client';
+
+@Injectable()
+export class WebhooksService {
+  constructor(private readonly db: DatabaseService) {}
+  async processStatusUpdate(payload: {
+    MessageSid: string;
+    MessageStatus: string;
+    Provider?: keyof typeof MessageService;
+    [key: string]: any;
+  }) {
+    const { MessageSid, MessageStatus, Provider } = payload;
+    const user = await this.db.user.findFirst();
+    if (!user) {
+      throw new Error('No users found. Please create a user first.');
+    }
+
+    const provider = Provider && MessageService[Provider] ? Provider : null;
+
+    let message = await this.db.message.findUnique({
+      where: { uuid: MessageSid },
+    });
+
+    if (!message) {
+      const consultation = await this.db.consultation.create({
+        data: {
+          status: 'SCHEDULED',
+          scheduledDate: new Date(),
+        },
+      });
+
+      message = await this.db.message.create({
+        data: {
+          uuid: MessageSid,
+          status: MessageStatus,
+          sentAt: new Date(),
+          provider: provider as MessageService,
+          content: 'Webhook status update message',
+          user: { connect: { id: user.id } },
+          consultation: { connect: { id: consultation.id } },
+        },
+      });
+    } else if (message.status !== MessageStatus) {
+      await this.db.auditLog.create({
+        data: {
+          messageId: message.id,
+          oldStatus: message.status,
+          newStatus: MessageStatus,
+        },
+      });
+
+      await this.db.message.update({
+        where: { id: message.id },
+        data: { status: MessageStatus },
+      });
+    }
+  }
+}


### PR DESCRIPTION
### Description

This PR implements the webhook functionality. It introduces an endpoint to receive delivery and read status updates from SMS/WhatsApp providers, updating the relevant `Message` records and logging status transitions.

### Changes Introduced

- Created `POST /webhooks/message-status` endpoint in `WebhooksController`
- Added `MessageStatusDto` for request validation
- Implemented `WebhooksService.processStatusUpdate()` logic:
  - Locates message via UUID (`MessageSid`)
  - If not found, creates fallback `Consultation` and `Message`
  - Updates message status
  - Logs status changes to `AuditLog`
- Integrated Prisma model for `Message`, `User`, and `Consultation`
- Included Swagger documentation for easy testing

### Sample Payload for Testing

```json
{
  "MessageSid": "SM1234567890",
  "MessageStatus": "delivered",
  "Provider": "SMS"
}
```

### Proof of work
![message_webhook_status](https://github.com/user-attachments/assets/df55945f-2ea9-44d2-bfae-3bb1f0beebcb)


Fixes: #17 