### PR TITLE
Implementation of Admin CRUD for user

### DIFF
--- a/admin/angular.json
+++ b/admin/angular.json
@@ -56,7 +56,13 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/admin/angular.json
+++ b/admin/angular.json
@@ -32,6 +32,7 @@
               }
             ],
             "styles": [
+              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
             ],
             "scripts": []
@@ -91,6 +92,7 @@
               }
             ],
             "styles": [
+              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
             ],
             "scripts": []

--- a/admin/package.json
+++ b/admin/package.json
@@ -11,10 +11,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^19.0.0",
+    "@angular/cdk": "^19.2.18",
     "@angular/common": "^19.0.0",
     "@angular/compiler": "^19.0.0",
     "@angular/core": "^19.0.0",
     "@angular/forms": "^19.0.0",
+    "@angular/material": "^19.2.18",
     "@angular/platform-browser": "^19.0.0",
     "@angular/platform-browser-dynamic": "^19.0.0",
     "@angular/router": "^19.0.0",

--- a/admin/src/app/app.component.html
+++ b/admin/src/app/app.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/admin/src/app/app.config.ts
+++ b/admin/src/app/app.config.ts
@@ -1,8 +1,9 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
-
+import { provideAnimations } from '@angular/platform-browser/animations'
 import { routes } from './app.routes';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideAnimations(), provideHttpClient(withInterceptors([])),]
 };

--- a/admin/src/app/app.routes.ts
+++ b/admin/src/app/app.routes.ts
@@ -2,9 +2,12 @@ import { Routes } from '@angular/router';
 import { UsersComponent } from './users/users.component';
 import { RoutePaths } from './constants/route-path.enum';
 import { UserFormComponent } from './user-form/user-form.component';
+import { ResourceManagerComponent } from './resource-manager/resource-manager.component';
 
 export const routes: Routes = [
     { path: '', redirectTo: RoutePaths.Users, pathMatch: 'full' },
     { path: RoutePaths.NewUser, component: UserFormComponent},
     { path: RoutePaths.Users, component: UsersComponent },
+    { path: 'user/:id', component:UserFormComponent },
+    { path: RoutePaths.ResourceManager, component: ResourceManagerComponent },
 ];

--- a/admin/src/app/app.routes.ts
+++ b/admin/src/app/app.routes.ts
@@ -1,3 +1,10 @@
 import { Routes } from '@angular/router';
+import { UsersComponent } from './users/users.component';
+import { RoutePaths } from './constants/route-path.enum';
+import { UserFormComponent } from './user-form/user-form.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+    { path: '', redirectTo: RoutePaths.Users, pathMatch: 'full' },
+    { path: RoutePaths.NewUser, component: UserFormComponent},
+    { path: RoutePaths.Users, component: UsersComponent },
+];

--- a/admin/src/app/constants/route-path.enum.ts
+++ b/admin/src/app/constants/route-path.enum.ts
@@ -1,0 +1,4 @@
+export enum RoutePaths {
+  Users = 'user',
+  NewUser = 'user-form',
+}

--- a/admin/src/app/constants/route-path.enum.ts
+++ b/admin/src/app/constants/route-path.enum.ts
@@ -1,4 +1,5 @@
 export enum RoutePaths {
   Users = 'user',
-  NewUser = 'user-form',
+  NewUser = 'user/new',
+  ResourceManager = 'resources'
 }

--- a/admin/src/app/models/api-response.model.ts
+++ b/admin/src/app/models/api-response.model.ts
@@ -1,0 +1,27 @@
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+}
+
+export interface PaginatedApiResponse<T> {
+  success: boolean;
+  status: string;
+  statusCode: number;
+  message: string;
+  data: {
+    users: T[];
+    total: number;
+    page: number;
+    limit: number;
+  };
+  timestamp: string;
+  requestId: string;
+  path: string;
+}
+
+export interface PaginationResult<T> {
+  users: T[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/admin/src/app/models/user.model.ts
+++ b/admin/src/app/models/user.model.ts
@@ -1,0 +1,86 @@
+export enum UserRole {
+  PATIENT = 'PATIENT',
+  PRACTITIONER = 'PRACTITIONER',
+  ADMIN = 'ADMIN',
+}
+
+export enum UserSex {
+  MALE = 'MALE',
+  FEMALE = 'FEMALE',
+  OTHER = 'OTHER',
+}
+
+export enum UserStatus {
+  APPROVED = 'APPROVED',
+  NOT_APPROVED = 'NOT_APPROVED',
+}
+
+export interface Organization {
+  id: number;
+  name: string;
+  logo?: string | null;
+  primaryColor?: string | null;
+  footerMarkdown?: string | null;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+}
+
+export interface Group {
+  id: number;
+  organizationId: number;
+  name: string;
+  description?: string | null;
+  sharedOnlyIncomingConsultation: boolean;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+}
+
+export interface Language {
+  id: number;
+  name: string;
+}
+
+export interface Speciality {
+  id: number;
+  name: string;
+}
+
+export interface User {
+  id: number;
+  role: UserRole;
+  firstName: string;
+  lastName: string;
+  email: string;
+  temporaryAccount: boolean;
+  phoneNumber?: string | null;
+  country?: string | null;
+  sex?: UserSex | null;
+  status: UserStatus;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+
+  organizations: Organization[];
+  groups: Group[];
+  spokenLanguages: Language[];
+  userSpecialities: Speciality[];
+}
+
+export interface CreateUserDto {
+  role: UserRole;
+  firstName: string;
+  lastName: string;
+  email: string;
+  password?: string;
+  temporaryAccount?: boolean;
+  phoneNumber?: string;
+  country?: string;
+  sex?: UserSex;
+  status?: UserStatus;
+  organisationIds: number[];
+  groupIds?: number[];      
+  languageIds?: number[];   
+  specialityIds?: number[]; 
+}
+
+export interface UpdateUserDto extends Partial<Omit<CreateUserDto, 'password'>> {
+}

--- a/admin/src/app/models/user.model.ts
+++ b/admin/src/app/models/user.model.ts
@@ -58,11 +58,10 @@ export interface User {
   status: UserStatus;
   createdAt: string | Date;
   updatedAt: string | Date;
-
-  organizations: Organization[];
-  groups: Group[];
-  spokenLanguages: Language[];
-  userSpecialities: Speciality[];
+  OrganizationMember: { organization: { id: number } }[];
+  GroupMember: { group: { id: number } }[];
+  languages: { language: { id: number } }[];
+  specialities: { speciality: { id: number } }[];
 }
 
 export interface CreateUserDto {

--- a/admin/src/app/resource-manager/resource-manager.component.html
+++ b/admin/src/app/resource-manager/resource-manager.component.html
@@ -1,47 +1,55 @@
 <mat-tab-group [(selectedIndex)]="selectedTabIndex" (selectedIndexChange)="onTabChange($event)">
-  <mat-tab *ngFor="let tab of tabs; let i = index" [label]="tab.label">
-    <div class="tab-content">
-      <div *ngIf="tab.type === 'group'" class="org-select">
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Select Organization</mat-label>
-          <mat-select [(ngModel)]="selectedOrganizationId" name="organizationSelect" (selectionChange)="onOrganizationChange()" required>
-            <mat-option *ngFor="let org of organizations" [value]="org.id">{{ org.name }}</mat-option>
-          </mat-select>
-        </mat-form-field>
+  @for (tab of tabs; track tab.label; let i = $index) {
+    <mat-tab [label]="tab.label">
+      <div class="tab-content">
+        @if (tab.type === 'group') {
+          <div class="org-select">
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>Select Organization</mat-label>
+              <mat-select [(ngModel)]="selectedOrganizationId" name="organizationSelect" (selectionChange)="onOrganizationChange()" required>
+                @for (org of organizations; track org.id) {
+                  <mat-option [value]="org.id">{{ org.name }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          </div>
+        }
+
+        <form [formGroup]="resourceForm" (ngSubmit)="onSubmit()">
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>{{ tab.label }} Name</mat-label>
+            <input matInput formControlName="name" [placeholder]="'Enter ' + tab.label + ' Name'" />
+          </mat-form-field>
+          <button mat-raised-button color="primary" type="submit">
+            {{ isEditMode ? 'Update' : 'Add' }}
+          </button>
+          @if (isEditMode) {
+            <button mat-button type="button" (click)="resetForm()">Cancel</button>
+          }
+        </form>
+
+        <table mat-table [dataSource]="resources" class="mat-elevation-z8">
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef>{{ tab.label }}</th>
+            <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef>Actions</th>
+            <td mat-cell *matCellDef="let element">
+              <button mat-icon-button (click)="editResource(element)">
+                <mat-icon>edit</mat-icon>
+              </button>
+              <button mat-icon-button color="warn" (click)="deleteResource(element.id)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
       </div>
-
-      <form [formGroup]="resourceForm" (ngSubmit)="onSubmit()">
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ tab.label }} Name</mat-label>
-          <input matInput formControlName="name" [placeholder]="'Enter ' + tab.label + ' Name'" />
-        </mat-form-field>
-        <button mat-raised-button color="primary" type="submit">
-          {{ isEditMode ? 'Update' : 'Add' }}
-        </button>
-        <button *ngIf="isEditMode" mat-button type="button" (click)="resetForm()">Cancel</button>
-      </form>
-
-      <table mat-table [dataSource]="resources" class="mat-elevation-z8">
-        <ng-container matColumnDef="name">
-          <th mat-header-cell *matHeaderCellDef>{{ tab.label }}</th>
-          <td mat-cell *matCellDef="let element">{{ element.name }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef>Actions</th>
-          <td mat-cell *matCellDef="let element">
-            <button mat-icon-button (click)="editResource(element)">
-              <mat-icon>edit</mat-icon>
-            </button>
-            <button mat-icon-button color="warn" (click)="deleteResource(element.id)">
-              <mat-icon>delete</mat-icon>
-            </button>
-          </td>
-        </ng-container>
-
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-      </table>
-    </div>
-  </mat-tab>
+    </mat-tab>
+  }
 </mat-tab-group>

--- a/admin/src/app/resource-manager/resource-manager.component.html
+++ b/admin/src/app/resource-manager/resource-manager.component.html
@@ -1,0 +1,47 @@
+<mat-tab-group [(selectedIndex)]="selectedTabIndex" (selectedIndexChange)="onTabChange($event)">
+  <mat-tab *ngFor="let tab of tabs; let i = index" [label]="tab.label">
+    <div class="tab-content">
+      <div *ngIf="tab.type === 'group'" class="org-select">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Select Organization</mat-label>
+          <mat-select [(ngModel)]="selectedOrganizationId" name="organizationSelect" (selectionChange)="onOrganizationChange()" required>
+            <mat-option *ngFor="let org of organizations" [value]="org.id">{{ org.name }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+
+      <form [formGroup]="resourceForm" (ngSubmit)="onSubmit()">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>{{ tab.label }} Name</mat-label>
+          <input matInput formControlName="name" [placeholder]="'Enter ' + tab.label + ' Name'" />
+        </mat-form-field>
+        <button mat-raised-button color="primary" type="submit">
+          {{ isEditMode ? 'Update' : 'Add' }}
+        </button>
+        <button *ngIf="isEditMode" mat-button type="button" (click)="resetForm()">Cancel</button>
+      </form>
+
+      <table mat-table [dataSource]="resources" class="mat-elevation-z8">
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>{{ tab.label }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Actions</th>
+          <td mat-cell *matCellDef="let element">
+            <button mat-icon-button (click)="editResource(element)">
+              <mat-icon>edit</mat-icon>
+            </button>
+            <button mat-icon-button color="warn" (click)="deleteResource(element.id)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+    </div>
+  </mat-tab>
+</mat-tab-group>

--- a/admin/src/app/resource-manager/resource-manager.component.scss
+++ b/admin/src/app/resource-manager/resource-manager.component.scss
@@ -1,0 +1,16 @@
+.tab-content {
+  padding: 16px;
+
+  .full-width {
+    width: 100%;
+  }
+
+  table {
+    width: 100%;
+    margin-top: 16px;
+  }
+
+  .org-select {
+    margin-bottom: 16px;
+  }
+}

--- a/admin/src/app/resource-manager/resource-manager.component.spec.ts
+++ b/admin/src/app/resource-manager/resource-manager.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResourceManagerComponent } from './resource-manager.component';
+
+describe('ResourceManagerComponent', () => {
+  let component: ResourceManagerComponent;
+  let fixture: ComponentFixture<ResourceManagerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResourceManagerComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ResourceManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/admin/src/app/resource-manager/resource-manager.component.ts
+++ b/admin/src/app/resource-manager/resource-manager.component.ts
@@ -1,0 +1,250 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatTableModule } from '@angular/material/table';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { SpecialityService } from '../services/speciality.service';
+import { LanguageService } from '../services/language.service';
+import { OrganizationService } from '../services/organization.service';
+import { GroupService } from '../services/group.service';
+import { SnackbarService } from '../services/snackbar.service';
+
+@Component({
+  selector: 'app-resource-manager',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatTabsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatTableModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSelectModule,
+  ],
+  templateUrl: './resource-manager.component.html',
+  styleUrls: ['./resource-manager.component.scss']
+})
+export class ResourceManagerComponent {
+  selectedTabIndex = 0;
+  resourceForm: FormGroup;
+  resources: any[] = [];
+  organizations: any[] = [];
+  selectedOrganizationId: number | null = null;
+  isEditMode = false;
+  editResourceId: number | null = null;
+
+  displayedColumns: string[] = ['name', 'actions'];
+
+  tabs = [
+    { label: 'Organizations', type: 'organization' },
+    { label: 'Groups', type: 'group' },
+    { label: 'Languages', type: 'language' },
+    { label: 'Specialities', type: 'speciality' },
+  ];
+
+  constructor(
+    private specialityService: SpecialityService,
+    private languageService: LanguageService,
+    private organizationService: OrganizationService,
+    private groupService: GroupService,
+    private snackBarService: SnackbarService,
+    private fb: FormBuilder
+  ) {
+    this.resourceForm = this.fb.group({
+      name: ['', Validators.required]
+    });
+    this.loadResources();
+    this.loadOrganizations();
+  }
+
+  onTabChange(index: number) {
+    this.selectedTabIndex = index;
+    this.resetForm();
+    this.loadResources();
+  }
+
+  loadOrganizations() {
+    this.organizationService.getAllOrganizations().subscribe({
+      next: (data) => this.organizations = data,
+      error: () => this.snackBarService.showError('Failed to load organizations')
+    });
+  }
+
+  loadResources() {
+    const type = this.tabs[this.selectedTabIndex].type;
+
+    if (type === 'organization') {
+      this.organizationService.getAllOrganizations().subscribe({
+        next: (data) => this.resources = data,
+        error: () => this.snackBarService.showError('Failed to load organizations')
+      });
+    } else if (type === 'group' && this.selectedOrganizationId) {
+      this.groupService.getGroupsByOrganization(this.selectedOrganizationId).subscribe({
+        next: (data) => this.resources = data,
+        error: () => this.snackBarService.showError('Failed to load groups')
+      });
+    } else if (type === 'language') {
+      this.languageService.getAllLanguages().subscribe({
+        next: (data) => this.resources = data,
+        error: () => this.snackBarService.showError('Failed to load languages')
+      });
+    } else if (type === 'speciality') {
+      this.specialityService.getAllSpecialities().subscribe({
+        next: (data) => this.resources = data,
+        error: () => this.snackBarService.showError('Failed to load specialities')
+      });
+    }
+  }
+
+  onOrganizationChange() {
+    this.loadResources();
+  }
+
+  onSubmit() {
+    if (this.resourceForm.invalid) return;
+
+    const type = this.tabs[this.selectedTabIndex].type;
+    const payload = { name: this.resourceForm.value.name };
+
+    if (this.isEditMode && this.editResourceId !== null) {
+      this.updateResource(type, this.editResourceId, payload);
+    } else {
+      this.createResource(type, payload);
+    }
+  }
+
+  createResource(type: string, payload: any) {
+    if (type === 'organization') {
+      this.organizationService.createOrganization(payload).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Organization created successfully');
+          this.postSave();
+        },
+        error: () => this.snackBarService.showError('Failed to create organization')
+      });
+    } else if (type === 'group' && this.selectedOrganizationId) {
+      this.groupService.createGroup(this.selectedOrganizationId, payload).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Group created successfully');
+          this.postSave();
+        },
+        error: () => this.snackBarService.showError('Failed to create group')
+      });
+    } else if (type === 'language') {
+      this.languageService.createLanguage(payload).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Language created successfully');
+          this.postSave();
+        },
+        error: () => this.snackBarService.showError('Failed to create language')
+      });
+    } else if (type === 'speciality') {
+      this.specialityService.createSpeciality(payload).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Speciality created successfully');
+          this.postSave();
+        },
+        error: () => this.snackBarService.showError('Failed to create speciality')
+      });
+    }
+  }
+
+  updateResource(type: string, id: number, payload: any) {
+    if (type === 'organization') {
+      this.organizationService.updateOrganization(id, payload).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Organization updated successfully');
+          this.postSave();
+        },
+        error: () => this.snackBarService.showError('Failed to update organization')
+      });
+    } else if (type === 'group' && this.selectedOrganizationId) {
+      this.groupService.updateGroup(this.selectedOrganizationId, id, payload).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Group updated successfully');
+          this.postSave();
+        },
+        error: () => this.snackBarService.showError('Failed to update group')
+      });
+    } else if (type === 'language') {
+      this.languageService.updateLanguage(id, payload).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Language updated successfully');
+          this.postSave();
+        },
+        error: () => this.snackBarService.showError('Failed to update language')
+      });
+    } else if (type === 'speciality') {
+      this.specialityService.updateSpeciality(id, payload).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Speciality updated successfully');
+          this.postSave();
+        },
+        error: () => this.snackBarService.showError('Failed to update speciality')
+      });
+    }
+  }
+
+  deleteResource(id: number) {
+    const type = this.tabs[this.selectedTabIndex].type;
+
+    if (type === 'organization') {
+      this.organizationService.deleteOrganization(id).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Organization deleted successfully');
+          this.loadResources();
+        },
+        error: () => this.snackBarService.showError('Failed to delete organization')
+      });
+    } else if (type === 'group' && this.selectedOrganizationId) {
+      this.groupService.deleteGroup(this.selectedOrganizationId, id).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Group deleted successfully');
+          this.loadResources();
+        },
+        error: () => this.snackBarService.showError('Failed to delete group')
+      });
+    } else if (type === 'language') {
+      this.languageService.deleteLanguage(id).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Language deleted successfully');
+          this.loadResources();
+        },
+        error: () => this.snackBarService.showError('Failed to delete language')
+      });
+    } else if (type === 'speciality') {
+      this.specialityService.deleteSpeciality(id).subscribe({
+        next: () => {
+          this.snackBarService.showSuccess('Speciality deleted successfully');
+          this.loadResources();
+        },
+        error: () => this.snackBarService.showError('Failed to delete speciality')
+      });
+    }
+  }
+
+  editResource(resource: any) {
+    this.isEditMode = true;
+    this.editResourceId = resource.id;
+    this.resourceForm.patchValue({ name: resource.name });
+  }
+
+  resetForm() {
+    this.resourceForm.reset();
+    this.isEditMode = false;
+    this.editResourceId = null;
+  }
+
+  postSave() {
+    this.resetForm();
+    this.loadResources();
+  }
+}

--- a/admin/src/app/services/group.service.spec.ts
+++ b/admin/src/app/services/group.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GroupService } from './group.service';
+
+describe('GroupService', () => {
+  let service: GroupService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GroupService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/admin/src/app/services/group.service.ts
+++ b/admin/src/app/services/group.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { Group } from '../models/user.model';
+import { ApiResponse } from '../models/api-response.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GroupService {
+  private baseUrl = `${environment.apiUrl}/v1/organization`;
+
+  constructor(private http: HttpClient) {}
+
+  getGroupsByOrganization(organizationId: number): Observable<Group[]> {
+    const url = `${this.baseUrl}/${organizationId}/groups`;
+    return this.http.get<ApiResponse<Group[]>>(url).pipe(
+      map(response => response.data)
+    );
+  }
+}

--- a/admin/src/app/services/group.service.ts
+++ b/admin/src/app/services/group.service.ts
@@ -10,14 +10,33 @@ import { ApiResponse } from '../models/api-response.model';
   providedIn: 'root'
 })
 export class GroupService {
-  private baseUrl = `${environment.apiUrl}/v1/organization`;
 
   constructor(private http: HttpClient) {}
 
   getGroupsByOrganization(organizationId: number): Observable<Group[]> {
-    const url = `${this.baseUrl}/${organizationId}/groups`;
+    const url = `${environment.apiUrl}/v1/organization/${organizationId}/groups`;
     return this.http.get<ApiResponse<Group[]>>(url).pipe(
       map(response => response.data)
     );
   }
+
+  createGroup(organizationId: number, group: { name: string; description?: string; sharedOnlyIncomingConsultation?: boolean }): Observable<Group> {
+    const url = `${environment.apiUrl}/v1/organization/${organizationId}/groups`;
+    return this.http.post<ApiResponse<Group>>(url, group).pipe(
+      map(response => response.data)
+    );
+  }
+
+  updateGroup(organizationId: number, groupId: number, group: { name: string; description?: string; sharedOnlyIncomingConsultation?: boolean }): Observable<Group> {
+    const url = `${environment.apiUrl}/v1/organization/${organizationId}/groups/${groupId}`;
+    return this.http.patch<ApiResponse<Group>>(url, group).pipe(
+      map(response => response.data)
+    );
+  }
+
+  deleteGroup(organizationId: number, groupId: number): Observable<any> {
+    const url = `${environment.apiUrl}/v1/organization/${organizationId}/groups/${groupId}`;
+    return this.http.delete<ApiResponse<any>>(url);
+  }
+
 }

--- a/admin/src/app/services/language.service.spec.ts
+++ b/admin/src/app/services/language.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LanguageService } from './language.service';
+
+describe('LanguageService', () => {
+  let service: LanguageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LanguageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/admin/src/app/services/language.service.ts
+++ b/admin/src/app/services/language.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { Language } from '../models/user.model';
+import { ApiResponse } from '../models/api-response.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LanguageService {
+  private apiUrl = `${environment.apiUrl}/v1/language`; // Adjust endpoint
+
+  constructor(private http: HttpClient) {}
+
+  getAllLanguages(): Observable<Language[]> {
+    return this.http.get<ApiResponse<Language[]>>(this.apiUrl).pipe(
+      map(response => response.data)
+    );
+  }
+}

--- a/admin/src/app/services/language.service.ts
+++ b/admin/src/app/services/language.service.ts
@@ -10,13 +10,29 @@ import { ApiResponse } from '../models/api-response.model';
   providedIn: 'root'
 })
 export class LanguageService {
-  private apiUrl = `${environment.apiUrl}/v1/language`; // Adjust endpoint
 
   constructor(private http: HttpClient) {}
 
   getAllLanguages(): Observable<Language[]> {
-    return this.http.get<ApiResponse<Language[]>>(this.apiUrl).pipe(
+    return this.http.get<ApiResponse<Language[]>>(`${environment.apiUrl}/v1/language`).pipe(
       map(response => response.data)
     );
   }
+  
+  createLanguage(language: { name: string }): Observable<Language> {
+  return this.http.post<ApiResponse<Language>>(`${environment.apiUrl}/v1/language`, language).pipe(
+    map(response => response.data)
+  );
+}
+
+updateLanguage(id: number, language: { name: string }): Observable<Language> {
+  return this.http.patch<ApiResponse<Language>>(`${environment.apiUrl}/v1/language/${id}`, language).pipe(
+    map(response => response.data)
+  );
+}
+
+deleteLanguage(id: number): Observable<any> {
+  return this.http.delete<ApiResponse<any>>(`${environment.apiUrl}/v1/language/${id}`);
+}
+
 }

--- a/admin/src/app/services/organization.service.spec.ts
+++ b/admin/src/app/services/organization.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { OrganizationService } from './organization.service';
+
+describe('OrganizationService', () => {
+  let service: OrganizationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(OrganizationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/admin/src/app/services/organization.service.ts
+++ b/admin/src/app/services/organization.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { Organization } from '../models/user.model';
+import { ApiResponse } from '../models/api-response.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrganizationService {
+  private apiUrl = `${environment.apiUrl}/v1/organization`; // Adjust endpoint
+
+  constructor(private http: HttpClient) {}
+
+  getAllOrganizations(): Observable<Organization[]> {
+    return this.http.get<ApiResponse<Organization[]>>(this.apiUrl).pipe(
+      map(response => response.data)
+    );
+  }
+}

--- a/admin/src/app/services/organization.service.ts
+++ b/admin/src/app/services/organization.service.ts
@@ -10,13 +10,29 @@ import { ApiResponse } from '../models/api-response.model';
   providedIn: 'root'
 })
 export class OrganizationService {
-  private apiUrl = `${environment.apiUrl}/v1/organization`; // Adjust endpoint
 
   constructor(private http: HttpClient) {}
 
   getAllOrganizations(): Observable<Organization[]> {
-    return this.http.get<ApiResponse<Organization[]>>(this.apiUrl).pipe(
+    return this.http.get<ApiResponse<Organization[]>>(`${environment.apiUrl}/v1/organization`).pipe(
       map(response => response.data)
     );
   }
+
+  createOrganization(organization: { name: string; logo?: string; primaryColor?: string; footerMarkdown?: string }): Observable<Organization> {
+    return this.http.post<ApiResponse<Organization>>(`${environment.apiUrl}/v1/organization`, organization).pipe(
+      map(response => response.data)
+    );
+  }
+
+  updateOrganization(id: number, organization: { name: string; logo?: string; primaryColor?: string; footerMarkdown?: string }): Observable<Organization> {
+    return this.http.patch<ApiResponse<Organization>>(`${environment.apiUrl}/v1/organization/${id}`, organization).pipe(
+      map(response => response.data)
+    );
+  }
+
+  deleteOrganization(id: number): Observable<any> {
+    return this.http.delete<ApiResponse<any>>(`${environment.apiUrl}/v1/organization/${id}`);
+  }
+
 }

--- a/admin/src/app/services/snackbar.service.spec.ts
+++ b/admin/src/app/services/snackbar.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SnackbarService } from './snackbar.service';
+
+describe('SnackbarService', () => {
+  let service: SnackbarService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SnackbarService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/admin/src/app/services/snackbar.service.ts
+++ b/admin/src/app/services/snackbar.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SnackbarService {
+  constructor(private snackBar: MatSnackBar) {}
+
+  showSuccess(message: string): void {
+    this.snackBar.open(message, 'Close', {
+      duration: 3000,
+      horizontalPosition: 'end',
+      verticalPosition: 'top',
+      panelClass: ['snackbar-success'],
+    });
+  }
+
+  showError(message: string): void {
+    this.snackBar.open(message, 'Close', {
+      duration: 3000,
+      horizontalPosition: 'end',
+      verticalPosition: 'top',
+      panelClass: ['snackbar-error'],
+    });
+  }
+
+  showInfo(message: string): void {
+    this.snackBar.open(message, 'Close', {
+      duration: 3000,
+      horizontalPosition: 'end',
+      verticalPosition: 'top',
+      panelClass: ['snackbar-info'],
+    });
+  }
+}

--- a/admin/src/app/services/speciality.service.spec.ts
+++ b/admin/src/app/services/speciality.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SpecialityService } from './speciality.service';
+
+describe('SpecialityService', () => {
+  let service: SpecialityService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SpecialityService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/admin/src/app/services/speciality.service.ts
+++ b/admin/src/app/services/speciality.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { Speciality } from '../models/user.model';
+import { ApiResponse } from '../models/api-response.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SpecialityService {
+  private apiUrl = `${environment.apiUrl}/v1/speciality`;
+
+  constructor(private http: HttpClient) {}
+
+  getAllSpecialities(): Observable<Speciality[]> {
+    return this.http.get<ApiResponse<Speciality[]>>(this.apiUrl).pipe(
+      map(response => response.data)
+    );
+  }
+}

--- a/admin/src/app/services/speciality.service.ts
+++ b/admin/src/app/services/speciality.service.ts
@@ -10,13 +10,29 @@ import { ApiResponse } from '../models/api-response.model';
   providedIn: 'root'
 })
 export class SpecialityService {
-  private apiUrl = `${environment.apiUrl}/v1/speciality`;
 
   constructor(private http: HttpClient) {}
 
   getAllSpecialities(): Observable<Speciality[]> {
-    return this.http.get<ApiResponse<Speciality[]>>(this.apiUrl).pipe(
+    return this.http.get<ApiResponse<Speciality[]>>(`${environment.apiUrl}/v1/speciality`).pipe(
       map(response => response.data)
     );
   }
+  
+  createSpeciality(speciality: { name: string }): Observable<Speciality> {
+    return this.http.post<ApiResponse<Speciality>>(`${environment.apiUrl}/v1/speciality`, speciality).pipe(
+      map(response => response.data)
+    );
+  }
+
+  updateSpeciality(id: number, speciality: { name: string }): Observable<Speciality> {
+    return this.http.patch<ApiResponse<Speciality>>(`${environment.apiUrl}/v1/speciality/${id}`, speciality).pipe(
+      map(response => response.data)
+    );
+  }
+
+  deleteSpeciality(id: number): Observable<any> {
+    return this.http.delete<ApiResponse<any>>(`${environment.apiUrl}/v1/speciality/${id}`);
+  }
+
 }

--- a/admin/src/app/services/user.service.spec.ts
+++ b/admin/src/app/services/user.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/admin/src/app/services/user.service.ts
+++ b/admin/src/app/services/user.service.ts
@@ -10,7 +10,6 @@ import { ApiResponse, PaginatedApiResponse, PaginationResult } from '../models/a
   providedIn: 'root'
 })
 export class UserService {
-  private apiUrl = `${environment.apiUrl}/v1/user`;
 
   constructor(private http: HttpClient) {}
 
@@ -34,7 +33,7 @@ export class UserService {
     if (sortBy) params = params.append('sortBy', sortBy);
     if (sortOrder) params = params.append('sortOrder', sortOrder);
 
-    return this.http.get<ApiResponse<User[]>>(this.apiUrl, {
+    return this.http.get<ApiResponse<User[]>>(`${environment.apiUrl}/v1/user`, {
       params
     }).pipe(
       map(response => ({
@@ -47,22 +46,22 @@ export class UserService {
   }
 
   getUserById(id: number): Observable<User> {
-    return this.http.get<ApiResponse<User>>(`${this.apiUrl}/${id}`, { 
+    return this.http.get<ApiResponse<User>>(`${environment.apiUrl}/v1/user/${id}`, {
     }).pipe(map(response => response.data));
   }
 
   createUser(userDto: CreateUserDto): Observable<User> {
-    return this.http.post<ApiResponse<User>>(this.apiUrl, userDto, {
+    return this.http.post<ApiResponse<User>>(`${environment.apiUrl}/v1/user`, userDto, {
     }).pipe(map(response => response.data));
   }
 
   updateUser(id: number, userDto: UpdateUserDto): Observable<User> {
-    return this.http.patch<ApiResponse<User>>(`${this.apiUrl}/${id}`, userDto, {
+    return this.http.patch<ApiResponse<User>>(`${environment.apiUrl}/v1/user/${id}`, userDto, {
     }).pipe(map(response => response.data));
   }
 
   deleteUser(id: number): Observable<User> {
-    return this.http.delete<ApiResponse<User>>(`${this.apiUrl}/${id}`, {
+    return this.http.delete<ApiResponse<User>>(`${environment.apiUrl}/v1/user/${id}`, {
     }).pipe(map(response => response.data));
   }
 }

--- a/admin/src/app/services/user.service.ts
+++ b/admin/src/app/services/user.service.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { User, CreateUserDto, UpdateUserDto, UserRole, UserStatus, UserSex } from '../models/user.model';
+import { ApiResponse, PaginatedApiResponse, PaginationResult } from '../models/api-response.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserService {
+  private apiUrl = `${environment.apiUrl}/v1/user`;
+
+  constructor(private http: HttpClient) {}
+
+  getUsers(
+    page: number = 1,
+    limit: number = 10,
+    search?: string,
+    role?: UserRole,
+    status?: UserStatus,
+    sex?: UserSex,
+    sortBy: string = 'createdAt',
+    sortOrder: 'asc' | 'desc' = 'desc'
+  ): Observable<PaginationResult<User>> {
+    let params = new HttpParams();
+    params = params.append('page', page.toString());
+    params = params.append('limit', limit.toString());
+    if (search) params = params.append('search', search);
+    if (role) params = params.append('role', role);
+    if (status) params = params.append('status', status);
+    if (sex) params = params.append('sex', sex);
+    if (sortBy) params = params.append('sortBy', sortBy);
+    if (sortOrder) params = params.append('sortOrder', sortOrder);
+
+    return this.http.get<ApiResponse<User[]>>(this.apiUrl, {
+      params
+    }).pipe(
+      map(response => ({
+        users: response.data,
+        total: response.data.length,
+        page,
+        limit
+      }))
+    );
+  }
+
+  getUserById(id: number): Observable<User> {
+    return this.http.get<ApiResponse<User>>(`${this.apiUrl}/${id}`, { 
+    }).pipe(map(response => response.data));
+  }
+
+  createUser(userDto: CreateUserDto): Observable<User> {
+    return this.http.post<ApiResponse<User>>(this.apiUrl, userDto, {
+    }).pipe(map(response => response.data));
+  }
+
+  updateUser(id: number, userDto: UpdateUserDto): Observable<User> {
+    return this.http.patch<ApiResponse<User>>(`${this.apiUrl}/${id}`, userDto, {
+    }).pipe(map(response => response.data));
+  }
+
+  deleteUser(id: number): Observable<User> {
+    return this.http.delete<ApiResponse<User>>(`${this.apiUrl}/${id}`, {
+    }).pipe(map(response => response.data));
+  }
+}

--- a/admin/src/app/user-form/user-form.component.html
+++ b/admin/src/app/user-form/user-form.component.html
@@ -21,26 +21,36 @@
       <mat-form-field appearance="fill">
         <mat-label>First Name</mat-label>
         <input matInput formControlName="firstName" />
-        <mat-error *ngIf="hasError('firstName', 'required')">First name is required.</mat-error>
+        @if (hasError('firstName', 'required')) {
+          <mat-error>First name is required.</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="fill">
         <mat-label>Last Name</mat-label>
         <input matInput formControlName="lastName" />
-        <mat-error *ngIf="hasError('lastName', 'required')">Last name is required.</mat-error>
+        @if (hasError('lastName', 'required')) {
+          <mat-error>Last name is required.</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="fill">
         <mat-label>Email</mat-label>
         <input matInput type="email" formControlName="email" />
-        <mat-error *ngIf="hasError('email', 'required')">Email is required.</mat-error>
-        <mat-error *ngIf="hasError('email', 'email')">Invalid email format.</mat-error>
+        @if (hasError('email', 'required')) {
+          <mat-error>Email is required.</mat-error>
+        }
+        @if (hasError('email', 'email')) {
+          <mat-error>Invalid email format.</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="fill">
         <mat-label>Phone Number</mat-label>
         <input matInput formControlName="phoneNumber" />
-        <mat-error *ngIf="hasError('phoneNumber', 'pattern')">Invalid phone format.</mat-error>
+        @if (hasError('phoneNumber', 'pattern')) {
+          <mat-error>Invalid phone format.</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="fill">

--- a/admin/src/app/user-form/user-form.component.html
+++ b/admin/src/app/user-form/user-form.component.html
@@ -1,0 +1,132 @@
+<div class="form-wrapper">
+  <h2 class="form-header">
+    @if (isEditMode) {
+      Edit User
+    } @else {
+      Add User
+    }
+    <button (click)="cancel()" mat-icon-button class="back-button">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+  </h2>
+
+  @if (loading) {
+    <div class="spinner-container">
+      <mat-spinner diameter="36"></mat-spinner>
+    </div>
+  }
+
+  <form [formGroup]="userForm" (ngSubmit)="onSubmit()">
+    <div class="form-grid">
+      <mat-form-field appearance="fill">
+        <mat-label>First Name</mat-label>
+        <input matInput formControlName="firstName" />
+        <mat-error *ngIf="hasError('firstName', 'required')">First name is required.</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Last Name</mat-label>
+        <input matInput formControlName="lastName" />
+        <mat-error *ngIf="hasError('lastName', 'required')">Last name is required.</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Email</mat-label>
+        <input matInput type="email" formControlName="email" />
+        <mat-error *ngIf="hasError('email', 'required')">Email is required.</mat-error>
+        <mat-error *ngIf="hasError('email', 'email')">Invalid email format.</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Phone Number</mat-label>
+        <input matInput formControlName="phoneNumber" />
+        <mat-error *ngIf="hasError('phoneNumber', 'pattern')">Invalid phone format.</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Country</mat-label>
+        <input matInput formControlName="country" />
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Sex</mat-label>
+        <mat-select formControlName="sex">
+          @for (sex of userSexes; track sex) {
+            <mat-option [value]="sex">{{ sex }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Role</mat-label>
+        <mat-select formControlName="role">
+          @for (role of userRoles; track role) {
+            <mat-option [value]="role">{{ role }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Status</mat-label>
+        <mat-select formControlName="status">
+          @for (status of userStatuses; track status) {
+            <mat-option [value]="status">{{ status }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-checkbox formControlName="temporaryAccount" class="temporary-checkbox">
+        Temporary Account
+      </mat-checkbox>
+    </div>
+
+    <div class="form-grid multi-selects">
+      <mat-form-field appearance="fill">
+        <mat-label>Organizations</mat-label>
+        <mat-select formControlName="organisationIds" multiple>
+          @for (org of organizations; track org.id) {
+            <mat-option [value]="org.id">{{ org.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Groups</mat-label>
+        <mat-select formControlName="groupIds" multiple>
+          @for (group of groups; track group.id) {
+            <mat-option [value]="group.id">{{ group.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Languages</mat-label>
+        <mat-select formControlName="languageIds" multiple>
+          @for (lang of languages; track lang.id) {
+            <mat-option [value]="lang.id">{{ lang.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Specialities</mat-label>
+        <mat-select formControlName="specialityIds" multiple>
+          @for (spec of specialities; track spec.id) {
+            <mat-option [value]="spec.id">{{ spec.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    <div class="form-actions">
+      <button type="button" mat-stroked-button color="warn" (click)="cancel()">Cancel</button>
+      <button type="submit" mat-raised-button color="primary" [disabled]="userForm.invalid || loading">
+        @if (isEditMode) {
+          Update
+        } @else {
+          Create
+        }
+      </button>
+    </div>
+  </form>
+</div>

--- a/admin/src/app/user-form/user-form.component.scss
+++ b/admin/src/app/user-form/user-form.component.scss
@@ -1,0 +1,67 @@
+.form-wrapper {
+  max-width: 1000px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  background-color: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+  font-family: "Helvetica Neue", sans-serif;
+}
+
+.form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+
+  .back-button {
+    font-size: 1rem;
+    color: #666;
+  }
+}
+
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  margin: 2rem 0;
+}
+::ng-deep .snackbar-success {
+  background-color: #4caf50;
+  color: #fff;
+}
+
+::ng-deep .snackbar-error {
+  background-color: #f44336;
+  color: #fff;
+}
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+
+  mat-form-field {
+    width: 100%;
+  }
+
+  .temporary-checkbox {
+    align-self: center;
+    margin-top: 1rem;
+  }
+}
+
+.multi-selects {
+  margin-top: 1rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+
+  button {
+    min-width: 120px;
+  }
+}

--- a/admin/src/app/user-form/user-form.component.spec.ts
+++ b/admin/src/app/user-form/user-form.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserFormComponent } from './user-form.component';
+
+describe('UserFormComponent', () => {
+  let component: UserFormComponent;
+  let fixture: ComponentFixture<UserFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserFormComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(UserFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/admin/src/app/user-form/user-form.component.ts
+++ b/admin/src/app/user-form/user-form.component.ts
@@ -18,6 +18,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { SnackbarService } from '../services/snackbar.service';
 
 @Component({
   selector: 'app-user-form',
@@ -63,7 +64,7 @@ export class UserFormComponent implements OnInit, OnDestroy {
     private groupService: GroupService,
     private languageService: LanguageService,
     private specialityService: SpecialityService,
-    private snackBar: MatSnackBar
+    private snackBarService: SnackbarService
   ) {}
 
   ngOnInit(): void {
@@ -134,13 +135,13 @@ export class UserFormComponent implements OnInit, OnDestroy {
               phoneNumber: userData.phoneNumber,
               country: userData.country,
               sex: userData.sex,
-              organisationIds: userData.organizations.map(org => org.id),
-              groupIds: userData.groups.map(group => group.id),
-              languageIds: userData.spokenLanguages.map(lang => lang.id),
-              specialityIds: userData.userSpecialities.map(spec => spec.id)
+              organisationIds: (userData.OrganizationMember ?? []).map(member => member.organization.id),
+              groupIds: (userData.GroupMember ?? []).map(member => member.group.id),
+              languageIds: (userData.languages ?? []).map(lang => lang.language.id),
+              specialityIds: (userData.specialities ?? []).map(spec => spec.speciality.id)
             });
 
-            const orgIds = userData.organizations.map(org => org.id);
+            const orgIds = userData.OrganizationMember.map(org => org.organization.id);
             this.loadGroupsForOrganizations(orgIds);
           }
 
@@ -212,20 +213,12 @@ export class UserFormComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       operation.subscribe({
         next: (user: User) => {
-          this.snackBar.open(`User ${this.isEditMode ? 'updated' : 'created'} successfully!`, 'Close', {
-            duration: 3000,
-            horizontalPosition: 'end',
-            verticalPosition: 'top',
-            panelClass: ['snackbar-success'],
-          });
+          this.snackBarService.showSuccess(`User ${this.isEditMode ? 'updated' : 'created'} successfully!`);
           this.router.navigate(['/user']);
         },
         error: (error: any) => {
           console.error(`Error ${this.isEditMode ? 'updating' : 'creating'} user:`, error);
-          this.snackBar.open(`Failed: ${error?.message || 'Unknown error'}`, 'Close', {
-            duration: 3000,
-            panelClass: ['snackbar-error'],
-          });
+          this.snackBarService.showError(`Failed: ${error?.message || 'Unknown error'}`);
           this.loading = false;
         }
       })

--- a/admin/src/app/user-form/user-form.component.ts
+++ b/admin/src/app/user-form/user-form.component.ts
@@ -152,8 +152,7 @@ export class UserFormComponent implements OnInit, OnDestroy {
           this.loading = false;
         },
         error: (error: any) => {
-          console.error('Error loading form data:', error);
-          alert(`Failed to load form data: ${error.message || 'Unknown error'}`);
+          this.snackBarService.showError(`Failed to load form data: ${error.message || 'Unknown error'}`);
           this.loading = false;
         }
       })
@@ -178,7 +177,7 @@ export class UserFormComponent implements OnInit, OnDestroy {
           this.groups = uniqueGroups;
         },
         error: err => {
-          console.error('Failed to load groups for selected organizations', err);
+          this.snackBarService.showError('Failed to load groups for selected organizations. Please try again.');
           this.groups = [];
         }
       })
@@ -188,7 +187,7 @@ export class UserFormComponent implements OnInit, OnDestroy {
   onSubmit(): void {
     if (this.userForm.invalid) {
       this.userForm.markAllAsTouched();
-      alert('Please fill out all required fields and correct any errors.');
+      this.snackBarService.showError('Please fill out all required fields and correct any errors.');
       return;
     }
 

--- a/admin/src/app/user-form/user-form.component.ts
+++ b/admin/src/app/user-form/user-form.component.ts
@@ -1,0 +1,243 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { UserService } from '../services/user.service';
+import { OrganizationService } from '../services/organization.service';
+import { GroupService } from '../services/group.service';
+import { LanguageService } from '../services/language.service';
+import { SpecialityService } from '../services/speciality.service';
+import { CreateUserDto, UpdateUserDto, User, UserRole, UserStatus, UserSex, Organization, Group, Language, Speciality } from '../models/user.model';
+import { Observable, Subscription, forkJoin } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar'
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'app-user-form',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatCheckboxModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './user-form.component.html',
+  styleUrls: ['./user-form.component.scss']
+})
+export class UserFormComponent implements OnInit, OnDestroy {
+  userForm!: FormGroup;
+  userId: number | null = null;
+  isEditMode: boolean = false;
+  loading: boolean = false;
+
+  organizations: Organization[] = [];
+  groups: Group[] = [];
+  languages: Language[] = [];
+  specialities: Speciality[] = [];
+
+  userRoles = Object.values(UserRole);
+  userStatuses = Object.values(UserStatus);
+  userSexes = Object.values(UserSex);
+
+  private subscriptions: Subscription = new Subscription();
+
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private userService: UserService,
+    private organizationService: OrganizationService,
+    private groupService: GroupService,
+    private languageService: LanguageService,
+    private specialityService: SpecialityService,
+    private snackBar: MatSnackBar
+  ) {}
+
+  ngOnInit(): void {
+    this.initForm();
+
+    this.subscriptions.add(
+      this.route.paramMap.subscribe(params => {
+        const id = params.get('id');
+        this.userId = id ? +id : null;
+        this.isEditMode = !!this.userId;
+        this.initForm();
+        this.loadFormData();
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  initForm(): void {
+    this.userForm = this.fb.group({
+      firstName: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(50), Validators.pattern(/^[a-zA-Z\s]+$/)]],
+      lastName: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(50), Validators.pattern(/^[a-zA-Z\s]+$/)]],
+      email: ['', [Validators.required, Validators.email, Validators.maxLength(255)]],
+      role: [UserRole.PATIENT, Validators.required],
+      status: [UserStatus.NOT_APPROVED, Validators.required],
+      temporaryAccount: [false],
+      phoneNumber: ['', [Validators.pattern(/^\+?[1-9]\d{1,14}$/)]],
+      country: ['', [Validators.minLength(2), Validators.maxLength(100)]],
+      sex: [UserSex.MALE],
+      organisationIds: [[] as number[], Validators.required],
+      groupIds: [[] as number[]],
+      languageIds: [[] as number[]],
+      specialityIds: [[] as number[]]
+    });
+  }
+
+  loadFormData(): void {
+    this.loading = true;
+
+    const orgs$ = this.organizationService.getAllOrganizations();
+    const languages$ = this.languageService.getAllLanguages();
+    const specialities$ = this.specialityService.getAllSpecialities();
+
+    const observables: Observable<any>[] = [orgs$, languages$, specialities$];
+
+    if (this.isEditMode && this.userId !== null) {
+      observables.push(this.userService.getUserById(this.userId));
+    }
+
+    this.subscriptions.add(
+      forkJoin(observables).subscribe({
+        next: (results: any[]) => {
+          this.organizations = results[0];
+          this.languages = results[1];
+          this.specialities = results[2];
+
+          if (this.isEditMode && this.userId !== null && results.length > 3 && results[3]) {
+            const userData: User = results[3];
+            this.userForm.patchValue({
+              firstName: userData.firstName,
+              lastName: userData.lastName,
+              email: userData.email,
+              role: userData.role,
+              status: userData.status,
+              temporaryAccount: userData.temporaryAccount,
+              phoneNumber: userData.phoneNumber,
+              country: userData.country,
+              sex: userData.sex,
+              organisationIds: userData.organizations.map(org => org.id),
+              groupIds: userData.groups.map(group => group.id),
+              languageIds: userData.spokenLanguages.map(lang => lang.id),
+              specialityIds: userData.userSpecialities.map(spec => spec.id)
+            });
+
+            const orgIds = userData.organizations.map(org => org.id);
+            this.loadGroupsForOrganizations(orgIds);
+          }
+
+          this.userForm.get('organisationIds')?.valueChanges.subscribe((orgIds: number[]) => {
+            this.loadGroupsForOrganizations(orgIds);
+          });
+
+          this.loading = false;
+        },
+        error: (error: any) => {
+          console.error('Error loading form data:', error);
+          alert(`Failed to load form data: ${error.message || 'Unknown error'}`);
+          this.loading = false;
+        }
+      })
+    );
+  }
+
+  loadGroupsForOrganizations(orgIds: number[]): void {
+    this.groups = [];
+    if (!orgIds || orgIds.length === 0) {
+      return;
+    }
+
+    const groupRequests = orgIds.map(id => this.groupService.getGroupsByOrganization(id));
+
+    this.subscriptions.add(
+      forkJoin(groupRequests).subscribe({
+        next: (groupLists: Group[][]) => {
+          const allGroups = groupLists.flat();
+          const uniqueGroups = allGroups.filter(
+            (group, index, self) => index === self.findIndex(g => g.id === group.id)
+          );
+          this.groups = uniqueGroups;
+        },
+        error: err => {
+          console.error('Failed to load groups for selected organizations', err);
+          this.groups = [];
+        }
+      })
+    );
+  }
+
+  onSubmit(): void {
+    if (this.userForm.invalid) {
+      this.userForm.markAllAsTouched();
+      alert('Please fill out all required fields and correct any errors.');
+      return;
+    }
+
+    this.loading = true;
+    const formValue = this.userForm.value;
+
+    let payload: CreateUserDto | UpdateUserDto;
+
+    if (this.isEditMode) {
+      payload = { ...formValue } as UpdateUserDto;
+    } else {
+      payload = {
+        ...(formValue as CreateUserDto),
+        password: 'defaultPassword123!'
+      };
+    }
+
+    const operation: Observable<User> = this.isEditMode && this.userId !== null
+      ? this.userService.updateUser(this.userId, payload as UpdateUserDto)
+      : this.userService.createUser(payload as CreateUserDto);
+
+    this.subscriptions.add(
+      operation.subscribe({
+        next: (user: User) => {
+          this.snackBar.open(`User ${this.isEditMode ? 'updated' : 'created'} successfully!`, 'Close', {
+            duration: 3000,
+            horizontalPosition: 'end',
+            verticalPosition: 'top',
+            panelClass: ['snackbar-success'],
+          });
+          this.router.navigate(['/user']);
+        },
+        error: (error: any) => {
+          console.error(`Error ${this.isEditMode ? 'updating' : 'creating'} user:`, error);
+          this.snackBar.open(`Failed: ${error?.message || 'Unknown error'}`, 'Close', {
+            duration: 3000,
+            panelClass: ['snackbar-error'],
+          });
+          this.loading = false;
+        }
+      })
+    );
+  }
+
+  hasError(controlName: string, errorType: string): boolean | undefined {
+    const control = this.userForm.get(controlName);
+    return control?.hasError(errorType) && (control?.touched || control?.dirty);
+  }
+
+  cancel(): void {
+    this.router.navigate(['/user']);
+  }
+}

--- a/admin/src/app/users/users.component.html
+++ b/admin/src/app/users/users.component.html
@@ -1,0 +1,128 @@
+<div class="users-container">
+  <h2 class="users-header">
+    Users
+    <button mat-raised-button color="primary" (click)="addNewUser()">Add New User</button>
+  </h2>
+
+  @if (loading) {
+    <div class="spinner-center">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  }
+
+  @if (!loading) {
+    <div class="filter-container">
+      <mat-form-field appearance="outline">
+        <mat-label>Search</mat-label>
+        <input matInput (keyup)="applyFilter($event)" [value]="searchQuery" placeholder="Name, email..." />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Role</mat-label>
+        <mat-select [(value)]="filterRole" (selectionChange)="loadUsers()">
+          <mat-option value="">All</mat-option>
+          <mat-option value="ADMIN">Admin</mat-option>
+          <mat-option value="PRACTITIONER">Practitioner</mat-option>
+          <mat-option value="PATIENT">Patient</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Status</mat-label>
+        <mat-select [(value)]="filterStatus" (selectionChange)="loadUsers()">
+          <mat-option value="">All</mat-option>
+          <mat-option value="APPROVED">Approved</mat-option>
+          <mat-option value="NOT_APPROVED">Not Approved</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Sex</mat-label>
+        <mat-select [(value)]="filterSex" (selectionChange)="loadUsers()">
+          <mat-option value="">All</mat-option>
+          <mat-option value="MALE">Male</mat-option>
+          <mat-option value="FEMALE">Female</mat-option>
+          <mat-option value="OTHER">Other</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    <div class="mat-elevation-z8">
+      <table mat-table [dataSource]="users" class="full-width-table">
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>Full Name</th>
+          <td mat-cell *matCellDef="let element">
+            {{ element.firstName }} {{ element.lastName }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="email">
+          <th mat-header-cell *matHeaderCellDef>Email</th>
+          <td mat-cell *matCellDef="let user">{{ user.email }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="phoneNumber">
+          <th mat-header-cell *matHeaderCellDef>Phone</th>
+          <td mat-cell *matCellDef="let user">{{ user.phoneNumber || 'N/A' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="country">
+          <th mat-header-cell *matHeaderCellDef>Country</th>
+          <td mat-cell *matCellDef="let user">{{ user.country || 'N/A' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="sex">
+          <th mat-header-cell *matHeaderCellDef>Sex</th>
+          <td mat-cell *matCellDef="let user">{{ user.sex || 'N/A' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="role">
+          <th mat-header-cell *matHeaderCellDef>Role</th>
+          <td mat-cell *matCellDef="let user">{{ user.role }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let user">
+            <mat-chip [color]="user.status === 'APPROVED' ? 'primary' : 'warn'" selected>
+              {{ user.status }}
+            </mat-chip>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="temporaryAccount">
+          <th mat-header-cell *matHeaderCellDef>Temp Account</th>
+          <td mat-cell *matCellDef="let user">
+            <mat-chip [color]="user.temporaryAccount ? 'accent' : 'default'" selected>
+              {{ user.temporaryAccount ? 'Yes' : 'No' }}
+            </mat-chip>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Actions</th>
+          <td mat-cell *matCellDef="let user">
+            <button mat-icon-button color="accent" (click)="editUser(user.id)">
+              <mat-icon>edit</mat-icon>
+            </button>
+            <button mat-icon-button color="warn" (click)="deleteUser(user)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+      </table>
+
+      <mat-paginator
+        [length]="totalUsers"
+        [pageSize]="pageSize"
+        [pageSizeOptions]="[5, 10, 20]"
+        (page)="pageChange($event)">
+      </mat-paginator>
+    </div>
+  }
+</div>

--- a/admin/src/app/users/users.component.scss
+++ b/admin/src/app/users/users.component.scss
@@ -1,0 +1,36 @@
+.users-container {
+  padding: 16px;
+  font-family: "Helvetica Neue", sans-serif;
+}
+
+.users-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.filter-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.table-container {
+  max-width: 600px;
+  margin: 0 auto;
+  overflow-x: auto;
+  padding-bottom: 24px;
+}
+
+.full-width-table {
+  width: 100%;
+  min-width: 500px;
+}
+
+.spinner-center {
+  display: flex;
+  justify-content: center;
+  margin: 32px 0;
+}

--- a/admin/src/app/users/users.component.spec.ts
+++ b/admin/src/app/users/users.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UsersComponent } from './users.component';
+
+describe('UsersComponent', () => {
+  let component: UsersComponent;
+  let fixture: ComponentFixture<UsersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UsersComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(UsersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/admin/src/app/users/users.component.ts
+++ b/admin/src/app/users/users.component.ts
@@ -1,0 +1,155 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { UserService } from '../services/user.service';
+import { User, UserRole, UserStatus, UserSex } from '../models/user.model'; 
+import { Subscription, Subject, debounceTime, distinctUntilChanged } from 'rxjs';
+import { Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTableModule } from '@angular/material/table';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatIconModule } from '@angular/material/icon';
+import { MatChipsModule } from '@angular/material/chips';
+
+@Component({
+  selector: 'app-users',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatIconModule,
+    MatChipsModule
+  ],
+  templateUrl: './users.component.html',
+  styleUrls: ['./users.component.scss']
+})
+export class UsersComponent implements OnInit, OnDestroy {
+  users: User[] = [];
+  totalUsers: number = 0;
+  currentPage: number = 1;
+  pageSize: number = 10;
+  loading: boolean = false;
+  
+  searchQuery: string = '';
+  filterRole: UserRole | '' = '';
+  filterStatus: UserStatus | '' = '';
+  filterSex: UserSex | '' = '';
+
+  displayedColumns: string[] = [
+    'name', 'email', 'phoneNumber', 'country',
+    'sex', 'role', 'status', 'temporaryAccount', 'actions'
+  ];
+
+  private searchSubject = new Subject<string>();
+  private subscriptions: Subscription = new Subscription();
+
+  constructor(
+    private userService: UserService,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.loadUsers();
+
+    this.subscriptions.add(
+      this.searchSubject.pipe(
+        debounceTime(300),
+        distinctUntilChanged()
+      ).subscribe(() => {
+        this.currentPage = 1;
+        this.loadUsers();
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  loadUsers(): void {
+    this.loading = true;
+    this.subscriptions.add(
+      this.userService.getUsers(
+        this.currentPage,
+        this.pageSize,
+        this.searchQuery,
+        this.filterRole === '' ? undefined : this.filterRole,
+        this.filterStatus === '' ? undefined : this.filterStatus,
+        this.filterSex === '' ? undefined : this.filterSex
+      ).subscribe({
+        next: (response) => {
+          console.log( 'fetched data:', response);
+          console.log('users:', response.users);
+          this.users = response.users;
+          this.totalUsers = response.total;
+          this.currentPage = response.page;
+          this.pageSize = response.limit;
+          this.loading = false;
+        },
+        error: (error: any) => {
+          console.error('Error loading users:', error);
+          alert(`Failed to load users: ${error.message || 'Unknown error'}`);
+          this.users = [];
+          this.totalUsers = 0;
+          this.loading = false;
+        }
+      })
+    );
+  }
+
+  applyFilter(event: KeyboardEvent): void {
+    const filterValue = (event.target as HTMLInputElement).value.trim().toLowerCase();
+    this.searchQuery = filterValue;
+    this.searchSubject.next(filterValue);
+  }
+
+  pageChange(event: { pageIndex: number; pageSize: number; length: number }): void {
+    this.currentPage = event.pageIndex + 1;
+    this.pageSize = event.pageSize;
+    this.loadUsers();
+  }
+
+  deleteUser(user: User): void {
+    if (confirm(`Are you sure you want to delete user ${user.firstName} ${user.lastName}?`)) {
+      this.loading = true;
+      this.subscriptions.add(
+        this.userService.deleteUser(user.id).subscribe({
+          next: () => {
+            alert('User deleted successfully!');
+            this.loadUsers();
+          },
+          error: (error: any) => {
+            console.error('Error deleting user:', error);
+            alert(`Failed to delete user: ${error.message || 'Unknown error'}`);
+            this.loading = false;
+          }
+        })
+      );
+    }
+  }
+
+  addNewUser(): void {
+    this.router.navigate(['/user-form']);
+  }
+
+  editUser(userId: number): void {
+    this.router.navigate(['/users', userId, 'edit']);
+  }
+
+  formatColumnHeader(col: string): string {
+    return col.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase());
+  }
+}

--- a/admin/src/app/users/users.component.ts
+++ b/admin/src/app/users/users.component.ts
@@ -12,9 +12,10 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
-import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
+import { SnackbarService } from '../services/snackbar.service';
 
 @Component({
   selector: 'app-users',
@@ -58,7 +59,8 @@ export class UsersComponent implements OnInit, OnDestroy {
 
   constructor(
     private userService: UserService,
-    private router: Router
+    private router: Router,
+    private snackBarService: SnackbarService,
   ) {}
 
   ngOnInit(): void {
@@ -100,8 +102,7 @@ export class UsersComponent implements OnInit, OnDestroy {
           this.loading = false;
         },
         error: (error: any) => {
-          console.error('Error loading users:', error);
-          alert(`Failed to load users: ${error.message || 'Unknown error'}`);
+          this.snackBarService.showError(`Failed to load users: ${error.message || 'Unknown error'}`);
           this.users = [];
           this.totalUsers = 0;
           this.loading = false;
@@ -116,7 +117,7 @@ export class UsersComponent implements OnInit, OnDestroy {
     this.searchSubject.next(filterValue);
   }
 
-  pageChange(event: { pageIndex: number; pageSize: number; length: number }): void {
+  pageChange(event: PageEvent): void {
     this.currentPage = event.pageIndex + 1;
     this.pageSize = event.pageSize;
     this.loadUsers();
@@ -128,12 +129,11 @@ export class UsersComponent implements OnInit, OnDestroy {
       this.subscriptions.add(
         this.userService.deleteUser(user.id).subscribe({
           next: () => {
-            alert('User deleted successfully!');
+            this.snackBarService.showSuccess('User deleted successfully!');
             this.loadUsers();
           },
           error: (error: any) => {
-            console.error('Error deleting user:', error);
-            alert(`Failed to delete user: ${error.message || 'Unknown error'}`);
+            this.snackBarService.showError(`Failed to delete user: ${error.message || 'Unknown error'}`);
             this.loading = false;
           }
         })

--- a/admin/src/app/users/users.component.ts
+++ b/admin/src/app/users/users.component.ts
@@ -142,14 +142,10 @@ export class UsersComponent implements OnInit, OnDestroy {
   }
 
   addNewUser(): void {
-    this.router.navigate(['/user-form']);
+    this.router.navigate(['/user/new']);
   }
 
   editUser(userId: number): void {
-    this.router.navigate(['/users', userId, 'edit']);
-  }
-
-  formatColumnHeader(col: string): string {
-    return col.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase());
+    this.router.navigate([`/user/${userId}`]);
   }
 }

--- a/admin/src/environments/environment.development.ts
+++ b/admin/src/environments/environment.development.ts
@@ -1,0 +1,4 @@
+export const environment = {
+    production: false,
+    apiUrl: 'http://localhost:3000/api',
+};

--- a/admin/src/environments/environment.prod.ts
+++ b/admin/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: '/api/v1',
+};

--- a/admin/src/environments/environment.prod.ts
+++ b/admin/src/environments/environment.prod.ts
@@ -1,4 +1,0 @@
-export const environment = {
-  production: true,
-  apiUrl: '/api/v1',
-};

--- a/admin/src/environments/environment.ts
+++ b/admin/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
-  production: false,
-  apiUrl: 'http://localhost:3000/api', // adjust port and prefix
+    production: true,
+    apiUrl: '/api/v1',
 };

--- a/admin/src/environments/environment.ts
+++ b/admin/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:3000/api', // adjust port and prefix
+};

--- a/admin/src/styles.scss
+++ b/admin/src/styles.scss
@@ -1,1 +1,15 @@
 /* You can add global styles to this file, and also import other style files */
+.snackbar-success {
+  background-color: #4caf50;
+  color: #fff;
+}
+
+.snackbar-error {
+  background-color: #f44336;
+  color: #fff;
+}
+
+.snackbar-info {
+  background-color: #2196f3;
+  color: #fff;
+}

--- a/backend/prisma/migrations/20250621174603_add_user_relations/migration.sql
+++ b/backend/prisma/migrations/20250621174603_add_user_relations/migration.sql
@@ -1,0 +1,282 @@
+-- CreateEnum
+CREATE TYPE "ConsultationStatus" AS ENUM ('SCHEDULED', 'WAITING', 'ACTIVE', 'COMPLETED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "UserRole" AS ENUM ('PATIENT', 'PRACTITIONER', 'ADMIN');
+
+-- CreateEnum
+CREATE TYPE "UserSex" AS ENUM ('MALE', 'FEMALE', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "UserStatus" AS ENUM ('APPROVED', 'NOT_APPROVED');
+
+-- CreateEnum
+CREATE TYPE "OrgMemberRole" AS ENUM ('ADMIN', 'MEMBER');
+
+-- CreateEnum
+CREATE TYPE "MessageService" AS ENUM ('SMS', 'EMAIL', 'WHATSAPP', 'MANUALLY');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" SERIAL NOT NULL,
+    "role" "UserRole" NOT NULL,
+    "firstName" VARCHAR(100) NOT NULL,
+    "lastName" VARCHAR(100) NOT NULL,
+    "email" VARCHAR(255) NOT NULL,
+    "password" VARCHAR(255) NOT NULL,
+    "temporaryAccount" BOOLEAN NOT NULL DEFAULT false,
+    "phoneNumber" VARCHAR(20),
+    "country" VARCHAR(100),
+    "sex" "UserSex",
+    "status" "UserStatus" NOT NULL DEFAULT 'NOT_APPROVED',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "organizations" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "logo" TEXT,
+    "primaryColor" TEXT,
+    "footerMarkdown" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "organizations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "organization_members" (
+    "id" SERIAL NOT NULL,
+    "organizationId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "role" "OrgMemberRole" NOT NULL DEFAULT 'MEMBER',
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "organization_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "groups" (
+    "id" SERIAL NOT NULL,
+    "organizationId" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "sharedOnlyIncomingConsultation" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "groups_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "group_members" (
+    "id" SERIAL NOT NULL,
+    "groupId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "group_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Language" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Language_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserLanguage" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "languageId" INTEGER NOT NULL,
+
+    CONSTRAINT "UserLanguage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Speciality" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Speciality_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserSpeciality" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "specialityId" INTEGER NOT NULL,
+
+    CONSTRAINT "UserSpeciality_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Consultation" (
+    "id" SERIAL NOT NULL,
+    "scheduledDate" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3),
+    "startedAt" TIMESTAMP(3),
+    "closedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "groupId" INTEGER,
+    "owner" INTEGER,
+    "messageService" "MessageService",
+    "whatsappTemplateId" INTEGER,
+    "status" "ConsultationStatus" NOT NULL DEFAULT 'SCHEDULED',
+
+    CONSTRAINT "Consultation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "mediasoup_servers" (
+    "id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "maxNumberOfSessions" INTEGER NOT NULL DEFAULT 100,
+    "active" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "mediasoup_servers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Participant" (
+    "id" SERIAL NOT NULL,
+    "consultationId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "isBeneficiary" BOOLEAN NOT NULL DEFAULT false,
+    "token" VARCHAR(255),
+    "joinedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Participant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "consultationId" INTEGER,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Whatsapp_Template" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "friendlyName" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "language" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "contentType" TEXT NOT NULL,
+    "variables" JSONB NOT NULL,
+    "actions" JSONB NOT NULL,
+    "approvalStatus" TEXT NOT NULL,
+    "createdAt" BIGINT NOT NULL,
+    "updatedAt" BIGINT NOT NULL,
+    "sid" TEXT NOT NULL,
+    "types" JSONB NOT NULL,
+    "url" TEXT NOT NULL,
+    "rejectionReason" TEXT NOT NULL,
+
+    CONSTRAINT "Whatsapp_Template_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sms_providers" (
+    "id" SERIAL NOT NULL,
+    "order" INTEGER NOT NULL,
+    "provider" TEXT,
+    "prefix" TEXT,
+    "isWhatsapp" BOOLEAN NOT NULL DEFAULT false,
+    "isDisabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sms_providers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "organizations_name_key" ON "organizations"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "organization_members_organizationId_userId_key" ON "organization_members"("organizationId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "group_members_groupId_userId_key" ON "group_members"("groupId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Language_name_key" ON "Language"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserLanguage_userId_languageId_key" ON "UserLanguage"("userId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Speciality_name_key" ON "Speciality"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserSpeciality_userId_specialityId_key" ON "UserSpeciality"("userId", "specialityId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mediasoup_servers_url_key" ON "mediasoup_servers"("url");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Participant_consultationId_userId_key" ON "Participant"("consultationId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sms_providers_order_key" ON "sms_providers"("order");
+
+-- AddForeignKey
+ALTER TABLE "organization_members" ADD CONSTRAINT "organization_members_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "organization_members" ADD CONSTRAINT "organization_members_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "groups" ADD CONSTRAINT "groups_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "group_members" ADD CONSTRAINT "group_members_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "group_members" ADD CONSTRAINT "group_members_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserLanguage" ADD CONSTRAINT "UserLanguage_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserLanguage" ADD CONSTRAINT "UserLanguage_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "Language"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserSpeciality" ADD CONSTRAINT "UserSpeciality_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserSpeciality" ADD CONSTRAINT "UserSpeciality_specialityId_fkey" FOREIGN KEY ("specialityId") REFERENCES "Speciality"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Consultation" ADD CONSTRAINT "Consultation_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "groups"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participant" ADD CONSTRAINT "Participant_consultationId_fkey" FOREIGN KEY ("consultationId") REFERENCES "Consultation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participant" ADD CONSTRAINT "Participant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_consultationId_fkey" FOREIGN KEY ("consultationId") REFERENCES "Consultation"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,6 +33,8 @@ model User {
   OrganizationMember OrganizationMember[]
   GroupMember        GroupMember[]
   Message            Message[]
+  languages          UserLanguage[]
+  specialities       UserSpeciality[]
 
   @@map("users")
 }
@@ -120,6 +122,44 @@ model GroupMember {
   @@unique([groupId, userId])
   @@map("group_members")
 }
+
+model Language {
+  id    Int    @id @default(autoincrement())
+  name  String @unique
+
+  users UserLanguage[]
+}
+
+model UserLanguage {
+  id         Int  @id @default(autoincrement())
+  userId     Int
+  languageId Int
+
+  user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  language Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, languageId])
+}
+
+model Speciality {
+  id   Int    @id @default(autoincrement())
+  name String @unique
+
+  users UserSpeciality[]
+}
+
+model UserSpeciality {
+  id           Int  @id @default(autoincrement())
+  userId       Int
+  specialityId Int
+
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  speciality Speciality @relation(fields: [specialityId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, specialityId])
+}
+
+
 
 //  Add the new models/enums that is necessary for consultation remainders
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,8 @@ import { APP_INTERCEPTOR, APP_FILTER } from '@nestjs/core';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { SmsProviderModule } from './sms_provider/sms_provider.module';
+import { LanguageModule } from './language/language.module';
+import { SpecialityModule } from './speciality/speciality.module';
 
 
 @Module({
@@ -29,7 +31,9 @@ import { SmsProviderModule } from './sms_provider/sms_provider.module';
     OrganizationModule,
     GroupModule,
     MediasoupModule,
-    SmsProviderModule
+    SmsProviderModule,
+    LanguageModule,
+    SpecialityModule
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/language/dto/create-language.dto.ts
+++ b/backend/src/language/dto/create-language.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CreateLanguageDto {
+  @IsString()
+  name: string;
+}

--- a/backend/src/language/dto/update-language.dto.ts
+++ b/backend/src/language/dto/update-language.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateLanguageDto } from './create-language.dto';
+
+export class UpdateLanguageDto extends PartialType(CreateLanguageDto) {}

--- a/backend/src/language/entities/language.entity.ts
+++ b/backend/src/language/entities/language.entity.ts
@@ -1,0 +1,1 @@
+export class Language {}

--- a/backend/src/language/language.controller.spec.ts
+++ b/backend/src/language/language.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LanguageController } from './language.controller';
+import { LanguageService } from './language.service';
+
+describe('LanguageController', () => {
+  let controller: LanguageController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LanguageController],
+      providers: [LanguageService],
+    }).compile();
+
+    controller = module.get<LanguageController>(LanguageController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/language/language.controller.ts
+++ b/backend/src/language/language.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { LanguageService } from './language.service';
+import { CreateLanguageDto } from './dto/create-language.dto';
+import { UpdateLanguageDto } from './dto/update-language.dto';
+
+@Controller('language')
+export class LanguageController {
+  constructor(private readonly service: LanguageService) {}
+
+  @Post()
+  create(@Body() dto: CreateLanguageDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateLanguageDto) {
+    return this.service.update(+id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(+id);
+  }
+}

--- a/backend/src/language/language.module.ts
+++ b/backend/src/language/language.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { LanguageService } from './language.service';
+import { LanguageController } from './language.controller';
+
+@Module({
+  controllers: [LanguageController],
+  providers: [LanguageService],
+})
+export class LanguageModule {}

--- a/backend/src/language/language.service.spec.ts
+++ b/backend/src/language/language.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LanguageService } from './language.service';
+
+describe('LanguageService', () => {
+  let service: LanguageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LanguageService],
+    }).compile();
+
+    service = module.get<LanguageService>(LanguageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/language/language.service.ts
+++ b/backend/src/language/language.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateLanguageDto } from './dto/create-language.dto';
+import { UpdateLanguageDto } from './dto/update-language.dto';
+import { DatabaseService } from 'src/database/database.service';
+
+@Injectable()
+export class LanguageService {
+  constructor(private prisma: DatabaseService) {}
+
+  create(data: CreateLanguageDto) {
+    return this.prisma.language.create({ data });
+  }
+
+  findAll() {
+    return this.prisma.language.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.language.findUnique({ where: { id } });
+  }
+
+  async update(id: number, data: UpdateLanguageDto) {
+    const existing = await this.prisma.language.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundException('Language not found');
+    return this.prisma.language.update({ where: { id }, data });
+  }
+
+  async remove(id: number) {
+    const existing = await this.prisma.language.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundException('Language not found');
+    return this.prisma.language.delete({ where: { id } });
+  }
+}

--- a/backend/src/speciality/dto/create-speciality.dto.ts
+++ b/backend/src/speciality/dto/create-speciality.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CreateSpecialityDto {
+  @IsString()
+  name: string;
+}

--- a/backend/src/speciality/dto/update-speciality.dto.ts
+++ b/backend/src/speciality/dto/update-speciality.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateSpecialityDto } from './create-speciality.dto';
+
+export class UpdateSpecialityDto extends PartialType(CreateSpecialityDto) {}

--- a/backend/src/speciality/entities/speciality.entity.ts
+++ b/backend/src/speciality/entities/speciality.entity.ts
@@ -1,0 +1,1 @@
+export class Speciality {}

--- a/backend/src/speciality/speciality.controller.spec.ts
+++ b/backend/src/speciality/speciality.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SpecialityController } from './speciality.controller';
+import { SpecialityService } from './speciality.service';
+
+describe('SpecialityController', () => {
+  let controller: SpecialityController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SpecialityController],
+      providers: [SpecialityService],
+    }).compile();
+
+    controller = module.get<SpecialityController>(SpecialityController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/speciality/speciality.controller.ts
+++ b/backend/src/speciality/speciality.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { SpecialityService } from './speciality.service';
+import { CreateSpecialityDto } from './dto/create-speciality.dto';
+import { UpdateSpecialityDto } from './dto/update-speciality.dto';
+
+@Controller('speciality')
+export class SpecialityController {
+  constructor(private readonly service: SpecialityService) {}
+
+  @Post()
+  create(@Body() dto: CreateSpecialityDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateSpecialityDto) {
+    return this.service.update(+id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(+id);
+  }
+}

--- a/backend/src/speciality/speciality.module.ts
+++ b/backend/src/speciality/speciality.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SpecialityService } from './speciality.service';
+import { SpecialityController } from './speciality.controller';
+
+@Module({
+  controllers: [SpecialityController],
+  providers: [SpecialityService],
+})
+export class SpecialityModule {}

--- a/backend/src/speciality/speciality.service.spec.ts
+++ b/backend/src/speciality/speciality.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SpecialityService } from './speciality.service';
+
+describe('SpecialityService', () => {
+  let service: SpecialityService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SpecialityService],
+    }).compile();
+
+    service = module.get<SpecialityService>(SpecialityService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/speciality/speciality.service.ts
+++ b/backend/src/speciality/speciality.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateSpecialityDto } from './dto/create-speciality.dto';
+import { UpdateSpecialityDto } from './dto/update-speciality.dto';
+import { DatabaseService } from 'src/database/database.service';
+
+@Injectable()
+export class SpecialityService {
+  constructor(private prisma: DatabaseService) {}
+
+  create(data: CreateSpecialityDto) {
+    return this.prisma.speciality.create({ data });
+  }
+
+  findAll() {
+    return this.prisma.speciality.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.speciality.findUnique({ where: { id } });
+  }
+
+  async update(id: number, data: UpdateSpecialityDto) {
+    const existing = await this.prisma.speciality.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundException('Speciality not found');
+    return this.prisma.speciality.update({ where: { id }, data });
+  }
+
+  async remove(id: number) {
+    const existing = await this.prisma.speciality.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundException('Speciality not found');
+    return this.prisma.speciality.delete({ where: { id } });
+  }
+}

--- a/backend/src/user/dto/create-user.dto.ts
+++ b/backend/src/user/dto/create-user.dto.ts
@@ -40,4 +40,16 @@ export class CreateUserDto {
     default: UserStatus.NOT_APPROVED,
   })
   status?: UserStatus;
+
+  @ApiProperty({ type: [Number], description: 'Organisation IDs the user belongs to' })
+  organisationIds: number[];
+
+  @ApiProperty({ type: [Number], description: 'Optional Group IDs', required: false })
+  groupIds?: number[];
+
+  @ApiProperty({ type: [Number], description: 'Language IDs', required: false })
+  languageIds?: number[];
+
+  @ApiProperty({ type: [Number], description: 'Speciality IDs', required: false })
+  specialityIds?: number[];
 }

--- a/backend/src/user/dto/user-response.dto.ts
+++ b/backend/src/user/dto/user-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Exclude } from 'class-transformer';
+import { Exclude, Expose, Type } from 'class-transformer';
 import { UserRole, UserSex, UserStatus } from '@prisma/client';
 
 export class UserResponseDto {
@@ -41,7 +41,23 @@ export class UserResponseDto {
 
   @ApiProperty({ description: 'Last update date' })
   updatedAt: Date;
+  
+  @ApiProperty({ type: [Number], description: 'Organisation IDs' })
+  @Expose()
+  organisationIds: number[];
 
+  @ApiProperty({ type: [Number], description: 'Group IDs', required: false })
+  @Expose()
+  groupIds?: number[];
+
+  @ApiProperty({ type: [Number], description: 'Language IDs', required: false })
+  @Expose()
+  languageIds?: number[];
+
+  @ApiProperty({ type: [Number], description: 'Speciality IDs', required: false })
+  @Expose()
+  specialityIds?: number[];
+  
   constructor(partial: Partial<UserResponseDto>) {
     Object.assign(this, partial);
   }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -38,7 +38,7 @@ import { Role } from 'src/auth/enums/role.enum';
 @UseGuards(AuthGuard, RolesGuard)
 export class UserController {
   constructor(private readonly userService: UserService) {}
-
+  @Roles(Role.ADMIN)
   @Post()
   @ApiOperation({ summary: 'Create a new user' })
   @ApiResponse({ status: 201, description: 'User created successfully' })
@@ -89,7 +89,7 @@ export class UserController {
       path: req.path,
     });
   }
-  // add who can access this
+  @Roles(Role.ADMIN)
   @Patch(':id')
   @ApiOperation({ summary: 'Update user by ID' })
   @ApiParam({ name: 'id', description: 'User ID', type: 'number' })
@@ -133,7 +133,7 @@ export class UserController {
       path: req.path,
     });
   }
-
+  @Roles(Role.ADMIN)
   @Delete(':id')
   @ApiOperation({ summary: 'Delete user by ID' })
   @ApiParam({ name: 'id', description: 'User ID', type: 'number' })

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -20,9 +20,19 @@ export class UserService {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async create(createUserDto: CreateUserDto): Promise<UserResponseDto> {
+    const {
+      email,
+      password,
+      organisationIds = [],
+      groupIds = [],
+      languageIds = [],
+      specialityIds = [],
+      ...rest
+    } = createUserDto;
+    
     // Check if email already exists
     const existingUser = await this.databaseService.user.findUnique({
-      where: { email: createUserDto.email },
+      where: { email },
     });
 
     if (existingUser) {
@@ -32,18 +42,72 @@ export class UserService {
     // Hash password
     const saltRounds = 12;
     const hashedPassword = await bcrypt.hash(
-      createUserDto.password,
+      password,
       saltRounds,
     );
 
     // Create user
-    const userData = {
-      ...createUserDto,
-      password: hashedPassword,
-    };
+    let user;
+    await this.databaseService.$transaction(async (tx) => {
+      user = await tx.user.create({
+        data: {
+          ...rest,
+          email,
+          password: hashedPassword,
+        },
+      });
 
-    const user = await this.databaseService.user.create({
-      data: userData,
+      const userId = user.id;
+
+      if (organisationIds.length > 0) {
+        await tx.organizationMember.createMany({
+          data: organisationIds.map((orgId) => ({
+            userId,
+            organizationId: orgId,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      if (groupIds.length > 0) {
+        await tx.groupMember.createMany({
+          data: groupIds.map((groupId) => ({
+            userId,
+            groupId,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      if (languageIds.length > 0) {
+        await tx.userLanguage.createMany({
+          data: languageIds.map((languageId) => ({
+            userId,
+            languageId,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      if (specialityIds.length > 0) {
+        await tx.userSpeciality.createMany({
+          data: specialityIds.map((specialityId) => ({
+            userId,
+            specialityId,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      user = await tx.user.findUnique({
+        where: { id: userId },
+        include: {
+          OrganizationMember: { include: { organization: true } },
+          GroupMember: { include: { group: true } },
+          languages: { include: { language: true } },
+          specialities: { include: { speciality: true } },
+        },
+      });
     });
 
     return plainToInstance(UserResponseDto, user, {
@@ -115,6 +179,12 @@ export class UserService {
   async findOne(id: number): Promise<UserResponseDto> {
     const user = await this.databaseService.user.findUnique({
       where: { id },
+      include: {
+        OrganizationMember: { include: { organization: true } },
+        GroupMember: { include: { group: true } },
+        languages: { include: { language: true } },
+        specialities: { include: { speciality: true } },
+      },
     });
 
     if (!user) {
@@ -144,6 +214,15 @@ export class UserService {
     id: number,
     updateUserDto: UpdateUserDto,
   ): Promise<UserResponseDto> {
+    const {
+      email,
+      organisationIds,
+      groupIds,
+      languageIds,
+      specialityIds,
+      ...rest
+    } = updateUserDto;
+
     // Check if user exists
     const existingUser = await this.databaseService.user.findUnique({
       where: { id },
@@ -155,10 +234,10 @@ export class UserService {
     }
 
     // Check email uniqueness if email is being updated
-    if (updateUserDto.email) {
+    if (email) {
       const emailExists = await this.databaseService.user.findFirst({
         where: {
-          email: updateUserDto.email,
+          email,
           id: { not: id },
         },
         select: { id: true },
@@ -168,10 +247,60 @@ export class UserService {
         throw new ConflictException('Email already exists');
       }
     }
+    let user;
+    await this.databaseService.$transaction(async (tx) => {
+      user = await tx.user.update({
+        where: { id },
+        data: { ...rest, email },
+      });
 
-    const user = await this.databaseService.user.update({
-      where: { id },
-      data: updateUserDto,
+      if (organisationIds) {
+        await tx.organizationMember.deleteMany({ where: { userId: id } });
+        if (organisationIds.length > 0) {
+          await tx.organizationMember.createMany({
+            data: organisationIds.map((orgId) => ({
+              userId: id,
+              organizationId: orgId,
+            })),
+          });
+        }
+      }
+
+      if (groupIds) {
+        await tx.groupMember.deleteMany({ where: { userId: id } });
+        if (groupIds.length > 0) {
+          await tx.groupMember.createMany({
+            data: groupIds.map((groupId) => ({
+              userId: id,
+              groupId,
+            })),
+          });
+        }
+      }
+
+      if (languageIds) {
+        await tx.userLanguage.deleteMany({ where: { userId: id } });
+        if (languageIds.length > 0) {
+          await tx.userLanguage.createMany({
+            data: languageIds.map((languageId) => ({
+              userId: id,
+              languageId,
+            })),
+          });
+        }
+      }
+
+      if (specialityIds) {
+        await tx.userSpeciality.deleteMany({ where: { userId: id } });
+        if (specialityIds.length > 0) {
+          await tx.userSpeciality.createMany({
+            data: specialityIds.map((specialityId) => ({
+              userId: id,
+              specialityId,
+            })),
+          });
+        }
+      }
     });
 
     return plainToInstance(UserResponseDto, user, {

--- a/backend/src/user/validation/user.validation.ts
+++ b/backend/src/user/validation/user.validation.ts
@@ -41,6 +41,10 @@ export const createUserSchema = z.object({
     .optional(),
   sex: z.nativeEnum(UserSex).optional(),
   status: z.nativeEnum(UserStatus).optional().default(UserStatus.NOT_APPROVED),
+  organisationIds: z.array(z.number().int().positive()),
+  groupIds: z.array(z.number().int().positive()).optional(),
+  languageIds: z.array(z.number().int().positive()).optional(),
+  specialityIds: z.array(z.number().int().positive()).optional(),
 });
 
 export const updateUserSchema = createUserSchema


### PR DESCRIPTION
### Description:
This PR implements the Admin-side implementation of user management, with full backend and frontend support for creating and managing users — including organization, group, language, and speciality associations.

Backend: 
- Added new Prisma schema models: `Language`  `Speciality`
- Created related modules, controllers, services: 
      `LanguageModule, LanguageService, LanguageController`
      `SpecialityModule, SpecialityService, SpecialityController`
- Updated DTOs for create/update with validation

Frontend:
- Implemented full user CRUD components
- Added services for:  `UserService` `LanguageService` `SpecialityService` `OrganizationService` `GroupService`
- Integrated role, status, and sex enums along with relational dropdowns

### Screenshots:

![Screenshot 2025-06-21 224240](https://github.com/user-attachments/assets/7e747405-e7ee-46eb-b891-d519f011afcb)

![Screenshot 2025-06-21 224341](https://github.com/user-attachments/assets/a0691e25-8172-4fb1-8ca4-8b8ec17a0f7d)

