### PR TITLE
feat(export): add CSV export module for consultations (admin-only end point)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { APP_INTERCEPTOR, APP_FILTER } from '@nestjs/core';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { SmsProviderModule } from './sms_provider/sms_provider.module';
+import { ExportModule } from './export/export.module';
 
 
 @Module({
@@ -29,7 +30,8 @@ import { SmsProviderModule } from './sms_provider/sms_provider.module';
     OrganizationModule,
     GroupModule,
     MediasoupModule,
-    SmsProviderModule
+    SmsProviderModule,
+    ExportModule
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/export/dto/export-consultations.dto.ts
+++ b/backend/src/export/dto/export-consultations.dto.ts
@@ -1,0 +1,45 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ConsultationStatus } from '@prisma/client';
+import { Type } from 'class-transformer';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+} from 'class-validator';
+
+export class ExportConsultationsDto {
+  @ApiPropertyOptional({
+    description: 'Filter consultations from this date (ISO 8601 format).',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter consultations up to this date (ISO 8601 format).',
+    example: '2024-12-31T23:59:59.999Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter consultations by a specific practitioner ID.',
+    example: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  practitionerId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter consultations by status.',
+    enum: ConsultationStatus,
+    example: ConsultationStatus.COMPLETED,
+  })
+  @IsOptional()
+  @IsEnum(ConsultationStatus)
+  status?: ConsultationStatus;
+} 

--- a/backend/src/export/export.controller.ts
+++ b/backend/src/export/export.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Res,
+  UseGuards,
+  Logger,
+  Header,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { Response } from 'express';
+import { AuthGuard } from 'src/auth/guards/auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from 'src/common/decorators/roles.decorator';
+import { Role } from 'src/auth/enums/role.enum';
+import { ExportService } from './export.service';
+import { ExportConsultationsDto } from './dto/export-consultations.dto';
+
+@ApiTags('Export')
+@ApiBearerAuth()
+@Controller('export')
+@UseGuards(AuthGuard, RolesGuard)
+export class ExportController {
+  private readonly logger = new Logger(ExportController.name);
+
+  constructor(private readonly exportService: ExportService) {}
+
+  @Get('consultations/csv')
+  @Roles(Role.ADMIN)
+  @ApiOperation({
+    summary: 'Export consultations to a CSV file (Admin only)',
+    description:
+      'Exports consultation data based on provided filters. Only accessible by users with the ADMIN role.',
+  })
+  @HttpCode(HttpStatus.OK)
+  @Header('Content-Type', 'text/csv')
+  async exportConsultations(
+    @Query() filters: ExportConsultationsDto,
+    @Res() res: Response,
+  ) {
+    this.logger.log(
+      `Received request to export consultations with filters: ${JSON.stringify(
+        filters,
+      )}`,
+    );
+
+    const csvData = await this.exportService.exportConsultationsAsCsv(filters);
+
+    const fileName = `consultation-export-${new Date().toISOString().split('T')[0]}.csv`;
+    res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+
+    res.send(csvData);
+  }
+} 

--- a/backend/src/export/export.module.ts
+++ b/backend/src/export/export.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ExportController } from './export.controller';
+import { ExportService } from './export.service';
+import { AuthModule } from 'src/auth/auth.module';
+import { DatabaseModule } from 'src/database/database.module';
+
+@Module({
+  imports: [AuthModule, DatabaseModule],
+  controllers: [ExportController],
+  providers: [ExportService],
+})
+export class ExportModule {} 

--- a/backend/src/export/export.service.ts
+++ b/backend/src/export/export.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from 'src/database/database.service';
+import { ExportConsultationsDto } from './dto/export-consultations.dto';
+import { CsvUtil } from './utils/csv.util';
+import { Prisma, UserRole } from '@prisma/client';
+
+@Injectable()
+export class ExportService {
+  private readonly logger = new Logger(ExportService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  async exportConsultationsAsCsv(
+    filters: ExportConsultationsDto,
+  ): Promise<string> {
+    this.logger.log(
+      `Starting CSV export process with filters: ${JSON.stringify(filters)}`,
+    );
+
+    const where = this.buildWhereClause(filters);
+
+    const consultations = await this.db.consultation.findMany({
+      where,
+      include: {
+        participants: {
+          include: {
+            user: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    if (consultations.length === 0) {
+      this.logger.log('No consultations found for the given filters.');
+      return 'No consultations found for the selected criteria.';
+    }
+
+    const formattedData = consultations.map((consultation) => {
+      const practitioner = consultation.participants.find(
+        (p) => p.user.role === UserRole.PRACTITIONER,
+      )?.user;
+      const patient = consultation.participants.find(
+        (p) => p.user.role === UserRole.PATIENT,
+      )?.user;
+
+      return {
+        'Consultation ID': consultation.id,
+        'Status': consultation.status,
+        'Scheduled Date': consultation.scheduledDate?.toISOString() ?? 'N/A',
+        'Created At': consultation.createdAt?.toISOString() ?? 'N/A',
+        'Started At': consultation.startedAt?.toISOString() ?? 'N/A',
+        'Closed At': consultation.closedAt?.toISOString() ?? 'N/A',
+        'Practitioner Name': practitioner
+          ? `${practitioner.firstName} ${practitioner.lastName}`
+          : 'N/A',
+        'Practitioner Email': practitioner?.email ?? 'N/A',
+        'Patient Name': patient
+          ? `${patient.firstName} ${patient.lastName}`
+          : 'N/A',
+        'Patient Email': patient?.email ?? 'N/A',
+      };
+    });
+
+    return CsvUtil.toCsv(formattedData);
+  }
+
+  private buildWhereClause(
+    filters: ExportConsultationsDto,
+  ): Prisma.ConsultationWhereInput {
+    const where: Prisma.ConsultationWhereInput = {};
+
+    if (filters.status) {
+      where.status = filters.status;
+    }
+
+    if (filters.dateFrom || filters.dateTo) {
+      where.createdAt = {};
+      if (filters.dateFrom) {
+        where.createdAt.gte = new Date(filters.dateFrom);
+      }
+      if (filters.dateTo) {
+        where.createdAt.lte = new Date(filters.dateTo);
+      }
+    }
+
+    if (filters.practitionerId) {
+      where.participants = {
+        some: {
+          userId: filters.practitionerId,
+          user: {
+            role: UserRole.PRACTITIONER,
+          },
+        },
+      };
+    }
+
+    return where;
+  }
+} 

--- a/backend/src/export/utils/csv.util.ts
+++ b/backend/src/export/utils/csv.util.ts
@@ -1,0 +1,44 @@
+import { Logger } from '@nestjs/common';
+
+export class CsvUtil {
+  private static readonly logger = new Logger(CsvUtil.name);
+
+  static toCsv<T extends Record<string, any>>(data: T[]): string {
+    if (!data || data.length === 0) {
+      this.logger.warn('CSV conversion attempted with no data.');
+      return '';
+    }
+
+    const headers = Object.keys(data[0]);
+    const csvRows = [headers.join(',')];
+
+    for (const row of data) {
+      const values = headers.map((header) => {
+        const value = row[header];
+        return this.escapeCsvField(value);
+      });
+      csvRows.push(values.join(','));
+    }
+
+    this.logger.log(`Successfully converted ${data.length} rows to CSV format.`);
+    return csvRows.join('\n');
+  }
+
+  private static escapeCsvField(field: any): string {
+    if (field === null || field === undefined) {
+      return '';
+    }
+
+    let stringField = String(field);
+
+    if (
+      stringField.includes(',') ||
+      stringField.includes('"') ||
+      stringField.includes('\n')
+    ) {
+      stringField = `"${stringField.replace(/"/g, '""')}"`;
+    }
+
+    return stringField;
+  }
+}


### PR DESCRIPTION
### Summary

* Added feature to export consultation data as CSV for Admin users.

### Changes Made

* Created `ExportModule` with controller and service.
* Added `GET /export/consultations/csv` endpoint.
* Implemented filters via `ExportConsultationsDto` (dateFrom, dateTo, practitionerId, status).
* Fetched data with Prisma and formatted it with practitioner and patient details.
* Created `CsvUtil` to convert JSON data to CSV format with proper escaping.

### Access Control

* Endpoint secured using `AuthGuard` and `RolesGuard`.
* Only accessible by users with `ADMIN` role.

Closes #36 

![image](https://github.com/user-attachments/assets/608175a0-8152-401f-a828-00189d331339)
