### PR TITLE
feat: add “Open Consultations” view with Join and Close actions (#25)

### DIFF
--- a/backend/src/consultation/consultation.controller.ts
+++ b/backend/src/consultation/consultation.controller.ts
@@ -49,16 +49,14 @@ import {
 } from './dto/end-consultation.dto';
 import { ConsultationPatientHistoryItemDto } from './dto/consultation-patient-history.dto';
 import { RateConsultationDto } from './dto/rate-consultation.dto';
-import {
-  CloseConsultationDto,
-} from './dto/close-consultation.dto';
-import {
-  JoinOpenConsultationDto,
-} from './dto/join-open-consultation.dto';
+import { CloseConsultationDto } from './dto/close-consultation.dto';
+import { JoinOpenConsultationDto } from './dto/join-open-consultation.dto';
 import {
   OpenConsultationResponseDto,
   OpenConsultationQueryDto,
 } from './dto/open-consultation.dto';
+import { HttpExceptionHelper } from 'src/common/helpers/execption/http-exception.helper';
+import { ResponseStatus } from 'src/common/helpers/response/response-status.enum';
 
 @ApiTags('consultation')
 @Controller('consultation')

--- a/backend/src/consultation/consultation.controller.ts
+++ b/backend/src/consultation/consultation.controller.ts
@@ -49,9 +49,16 @@ import {
 } from './dto/end-consultation.dto';
 import { ConsultationPatientHistoryItemDto } from './dto/consultation-patient-history.dto';
 import { RateConsultationDto } from './dto/rate-consultation.dto';
-import { CloseConsultationDto, CloseConsultationResponseDto } from './dto/close-consultation.dto';
-import { JoinOpenConsultationDto, JoinOpenConsultationResponseDto } from './dto/join-open-consultation.dto';
-import { OpenConsultationResponseDto, OpenConsultationQueryDto } from './dto/open-consultation.dto';
+import {
+  CloseConsultationDto,
+} from './dto/close-consultation.dto';
+import {
+  JoinOpenConsultationDto,
+} from './dto/join-open-consultation.dto';
+import {
+  OpenConsultationResponseDto,
+  OpenConsultationQueryDto,
+} from './dto/open-consultation.dto';
 
 @ApiTags('consultation')
 @Controller('consultation')
@@ -396,38 +403,40 @@ export class ConsultationController {
   @ApiBody({ type: JoinOpenConsultationDto })
   @ApiOkResponse({
     description: 'Successfully rejoined consultation',
-    type: ApiResponseDto<JoinOpenConsultationResponseDto>,
+    type: ApiResponseDto<JoinConsultationResponseDto>,
   })
   @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async joinOpenConsultation(
     @Body() dto: JoinOpenConsultationDto,
     @Query('practitionerId', UserIdParamPipe) practitionerId: number,
-  ): Promise<ApiResponseDto<JoinOpenConsultationResponseDto>> {
-    return this.consultationService.joinOpenConsultation(
+  ): Promise<ApiResponseDto<JoinConsultationResponseDto>> {
+    return this.consultationService.joinAsPractitioner(
       dto.consultationId,
       practitionerId,
     );
   }
-
   @Post('/open/close')
   @ApiOperation({
-    summary: 'Close an open consultation',
+    summary: 'Close an open consultation - Deprecated: Use /consultation/end',
+    deprecated: true,
   })
   @ApiBody({ type: CloseConsultationDto })
   @ApiOkResponse({
     description: 'Consultation closed successfully',
-    type: ApiResponseDto<CloseConsultationResponseDto>,
+    type: ApiResponseDto<EndConsultationResponseDto>,
   })
   @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async closeConsultation(
     @Body() dto: CloseConsultationDto,
     @Query('practitionerId', UserIdParamPipe) practitionerId: number,
-  ): Promise<ApiResponseDto<CloseConsultationResponseDto>> {
-    return this.consultationService.closeConsultation(
-      dto.consultationId,
-      practitionerId,
-      dto.reason,
-    );
+  ): Promise<ApiResponseDto<EndConsultationResponseDto>> {
+    const endDto: EndConsultationDto = {
+      consultationId: dto.consultationId,
+      action: 'close',
+      reason: dto.reason,
+    };
+
+    return this.consultationService.endConsultation(endDto, practitionerId);
   }
 
   @Get('/open/:id/details')

--- a/backend/src/consultation/consultation.gateway.ts
+++ b/backend/src/consultation/consultation.gateway.ts
@@ -13,7 +13,7 @@ import { ConsultationService } from './consultation.service';
 import { EndConsultationDto } from './dto/end-consultation.dto';
 import { RateConsultationDto } from './dto/rate-consultation.dto';
 import { ConsultationStatus, UserRole } from '@prisma/client';
-
+import { forwardRef, Inject } from '@nestjs/common';
 @WebSocketGateway({ namespace: '/consultation', cors: true })
 export class ConsultationGateway
   implements OnGatewayConnection, OnGatewayDisconnect
@@ -22,6 +22,7 @@ export class ConsultationGateway
 
   constructor(
     private readonly databaseService: DatabaseService,
+    @Inject(forwardRef(() => ConsultationService))
     private readonly consultationService: ConsultationService,
   ) {}
 

--- a/backend/src/consultation/dto/close-consultation.dto.ts
+++ b/backend/src/consultation/dto/close-consultation.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class CloseConsultationDto {
+  @ApiProperty({ description: 'Consultation ID to close' })
+  @Type(() => Number)
+  @IsNumber()
+  consultationId: number;
+
+  @ApiProperty({
+    description: 'Reason for closing the consultation',
+    required: false,
+  })
+  @IsOptional()
+  reason?: string;
+}
+
+export class CloseConsultationResponseDto {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'HTTP status code' })
+  statusCode: number;
+
+  @ApiProperty({ description: 'Response message' })
+  message: string;
+
+  @ApiProperty({ description: 'Consultation ID that was closed' })
+  consultationId: number;
+
+  @ApiProperty({ description: 'When the consultation was closed' })
+  closedAt: Date;
+}

--- a/backend/src/consultation/dto/end-consultation.dto.ts
+++ b/backend/src/consultation/dto/end-consultation.dto.ts
@@ -1,4 +1,10 @@
-import { IsIn, IsNotEmpty, IsNumber } from 'class-validator';
+import {
+  IsIn,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export const END_CONSULTATION_ACTIONS = [
@@ -21,6 +27,10 @@ export class EndConsultationDto {
   })
   @IsIn(END_CONSULTATION_ACTIONS)
   action: EndConsultationAction;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
 }
 
 export class EndConsultationResponseDto {

--- a/backend/src/consultation/dto/join-consultation.dto.ts
+++ b/backend/src/consultation/dto/join-consultation.dto.ts
@@ -5,38 +5,51 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
  * DTO for joining a consultation as a patient or practitioner.
  */
 export class JoinConsultationDto {
- @ApiProperty({
-  description: 'ID of the user joining the consultation',
-  example: 123,
-  type: Number,
-  minimum: 1,
- })
- @IsInt({ message: 'userId must be an integer' })
- @IsPositive({ message: 'userId must be a positive integer' })
- userId: number;
+  @ApiProperty({
+    description: 'ID of the user joining the consultation',
+    example: 123,
+    type: Number,
+    minimum: 1,
+  })
+  @IsInt({ message: 'userId must be an integer' })
+  @IsPositive({ message: 'userId must be a positive integer' })
+  userId: number;
 }
 
 /**
  * Standardized response DTO for joining a consultation.
  */
 export class JoinConsultationResponseDto {
- @ApiProperty({ description: 'Indicates if the join was successful', example: true })
- success: boolean;
+  @ApiProperty({
+    description: 'Indicates if the join was successful',
+    example: true,
+  })
+  success: boolean;
 
- @ApiProperty({ description: 'HTTP status code', example: 200 })
- statusCode: number;
+  @ApiProperty({ description: 'HTTP status code', example: 200 })
+  statusCode: number;
 
- @ApiProperty({ description: 'Response message', example: 'Joined consultation successfully' })
- message: string;
+  @ApiProperty({
+    description: 'Response message',
+    example: 'Joined consultation successfully',
+  })
+  message: string;
 
- @ApiPropertyOptional({
-  description: 'ID of the consultation joined',
-  example: 456,
-  type: Number,
- })
- consultationId?: number;
+  @ApiPropertyOptional({
+    description: 'ID of the consultation joined',
+    example: 456,
+    type: Number,
+  })
+  consultationId?: number;
 
- constructor(partial: Partial<JoinConsultationResponseDto>) {
-  Object.assign(this, partial);
- }
+  @ApiPropertyOptional({
+    description: 'URL for the session, if applicable',
+    example: '/session/consultation/456',
+    type: String,
+  })
+  sessionUrl?: string;
+
+  constructor(partial: Partial<JoinConsultationResponseDto>) {
+    Object.assign(this, partial);
+  }
 }

--- a/backend/src/consultation/dto/join-open-consultation.dto.ts
+++ b/backend/src/consultation/dto/join-open-consultation.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class JoinOpenConsultationDto {
+  @ApiProperty({ description: 'Consultation ID to join' })
+  @Type(() => Number)
+  @IsNumber()
+  consultationId: number;
+}
+
+export class JoinOpenConsultationResponseDto {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'HTTP status code' })
+  statusCode: number;
+
+  @ApiProperty({ description: 'Response message' })
+  message: string;
+
+  @ApiProperty({ description: 'Consultation ID that was joined' })
+  consultationId: number;
+
+  @ApiProperty({
+    description: 'Session URL for real-time consultation',
+    nullable: true,
+  })
+  sessionUrl?: string;
+}

--- a/backend/src/consultation/dto/open-consultation.dto.ts
+++ b/backend/src/consultation/dto/open-consultation.dto.ts
@@ -1,0 +1,181 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ConsultationStatus, UserSex } from '@prisma/client';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class OpenConsultationQueryDto {
+  @ApiProperty({
+    description: 'Page number for pagination',
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({
+    description: 'Number of items per page',
+    default: 10,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  limit?: number = 10;
+}
+
+export class OpenConsultationPatientDto {
+  @ApiProperty({ description: 'Patient ID' })
+  id: number;
+
+  @ApiProperty({ description: 'Patient first name', nullable: true })
+  firstName: string | null;
+
+  @ApiProperty({ description: 'Patient last name', nullable: true })
+  lastName: string | null;
+
+  @ApiProperty({
+    description: 'Patient initials (fallback if names unavailable)',
+  })
+  initials: string;
+
+  @ApiProperty({
+    description: 'Patient sex',
+    enum: UserSex,
+    nullable: true,
+  })
+  sex: UserSex | null;
+
+  @ApiProperty({
+    description: 'Whether patient is currently offline',
+    default: false,
+  })
+  isOffline: boolean;
+}
+
+export class OpenConsultationItemDto {
+  @ApiProperty({ description: 'Consultation ID' })
+  id: number;
+
+  @ApiProperty({
+    description: 'Patient information',
+    type: OpenConsultationPatientDto,
+  })
+  patient: OpenConsultationPatientDto;
+
+  @ApiProperty({
+    description: 'Time since consultation started (formatted string)',
+  })
+  timeSinceStart: string;
+
+  @ApiProperty({ description: 'Number of active participants' })
+  participantCount: number;
+
+  @ApiProperty({
+    description: 'Last message or status preview',
+    nullable: true,
+  })
+  lastMessage: string | null;
+
+  @ApiProperty({
+    description: 'Consultation status',
+    enum: ConsultationStatus,
+  })
+  status?: ConsultationStatus;
+
+  @ApiProperty({ description: 'When consultation started' })
+  startedAt: Date;
+
+  @ApiProperty({
+    description: 'Group name if consultation belongs to a group',
+    nullable: true,
+  })
+  groupName: string | null;
+}
+
+export class OpenConsultationResponseDto {
+  @ApiProperty({
+    description: 'List of open consultations',
+    type: [OpenConsultationItemDto],
+  })
+  consultations: OpenConsultationItemDto[];
+
+  @ApiProperty({ description: 'Total number of open consultations' })
+  total: number;
+
+  @ApiProperty({ description: 'Current page number' })
+  currentPage: number;
+
+  @ApiProperty({ description: 'Total number of pages' })
+  totalPages: number;
+
+  @ApiProperty({ description: 'Number of items per page' })
+  limit: number;
+
+  @ApiProperty({ description: 'Whether there are more pages' })
+  hasNextPage: boolean;
+
+  @ApiProperty({ description: 'Whether there is a previous page' })
+  hasPreviousPage: boolean;
+}
+
+export class JoinOpenConsultationDto {
+  @ApiProperty({ description: 'Consultation ID to join' })
+  @Type(() => Number)
+  @IsNumber()
+  consultationId: number;
+}
+
+export class JoinOpenConsultationResponseDto {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'HTTP status code' })
+  statusCode: number;
+
+  @ApiProperty({ description: 'Response message' })
+  message: string;
+
+  @ApiProperty({ description: 'Consultation ID that was joined' })
+  consultationId: number;
+
+  @ApiProperty({
+    description: 'Session URL for real-time consultation',
+    nullable: true,
+  })
+  sessionUrl?: string;
+}
+
+export class CloseConsultationDto {
+  @ApiProperty({ description: 'Consultation ID to close' })
+  @Type(() => Number)
+  @IsNumber()
+  consultationId: number;
+
+  @ApiProperty({
+    description: 'Reason for closing the consultation',
+    required: false,
+  })
+  @IsOptional()
+  reason?: string;
+}
+
+export class CloseConsultationResponseDto {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'HTTP status code' })
+  statusCode: number;
+
+  @ApiProperty({ description: 'Response message' })
+  message: string;
+
+  @ApiProperty({ description: 'Consultation ID that was closed' })
+  consultationId: number;
+
+  @ApiProperty({ description: 'When the consultation was closed' })
+  closedAt: Date;
+}

--- a/backend/src/consultation/dto/open-consultation.dto.ts
+++ b/backend/src/consultation/dto/open-consultation.dto.ts
@@ -1,31 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ConsultationStatus, UserSex } from '@prisma/client';
-import { Type } from 'class-transformer';
-import { IsNumber, IsOptional, Min } from 'class-validator';
-
-export class OpenConsultationQueryDto {
-  @ApiProperty({
-    description: 'Page number for pagination',
-    default: 1,
-    minimum: 1,
-  })
-  @IsOptional()
-  @Type(() => Number)
-  @IsNumber()
-  @Min(1)
-  page?: number = 1;
-
-  @ApiProperty({
-    description: 'Number of items per page',
-    default: 10,
-    minimum: 1,
-  })
-  @IsOptional()
-  @Type(() => Number)
-  @IsNumber()
-  @Min(1)
-  limit?: number = 10;
-}
+import { Transform, Type } from 'class-transformer';
+import { IsInt, IsNumber, IsOptional, Min } from 'class-validator';
 
 export class OpenConsultationPatientDto {
   @ApiProperty({ description: 'Patient ID' })
@@ -178,4 +154,25 @@ export class CloseConsultationResponseDto {
 
   @ApiProperty({ description: 'When the consultation was closed' })
   closedAt: Date;
+}
+
+export class OpenConsultationQueryDto {
+  @IsNumber()
+  @IsInt()
+  @Transform(({ value }) => parseInt(value, 10))
+  practitionerId: number;
+
+  @IsOptional()
+  @IsNumber()
+  @IsInt()
+  @Min(1)
+  @Transform(({ value }) => (value ? parseInt(value, 10) : 1))
+  page?: number = 1;
+
+  @IsOptional()
+  @IsNumber()
+  @IsInt()
+  @Min(1)
+  @Transform(({ value }) => (value ? parseInt(value, 10) : 10))
+  limit?: number = 10;
 }

--- a/practitioner/src/app/app.component.ts
+++ b/practitioner/src/app/app.component.ts
@@ -27,7 +27,7 @@ export class AppComponent implements OnInit {
   activeConsultations: number | undefined = 0;
   loginChecked = computed(() => this.authService.loginChecked());
   isLoggedIn = computed(() => this.authService.isLoggedIn());
-  private iconNames = ['warning', 'download', 'chevron-right', 'chevron-left'];
+  private iconNames = ['warning', 'download', 'chevron-right','x'];
 
   constructor(
     private iconRegistry: SvgIconRegistryService,
@@ -45,7 +45,6 @@ export class AppComponent implements OnInit {
         this.iconRegistry
           .loadSvg(`assets/svg/${iconName}.svg`, iconName)
           ?.subscribe({
-            next: () => console.log(`Icon ${iconName} registered successfully`),
             error: (error) =>
               console.error(`Failed to register icon ${iconName}:`, error),
           });

--- a/practitioner/src/app/components/open-consultation-card/open-consultation-card.component.html
+++ b/practitioner/src/app/components/open-consultation-card/open-consultation-card.component.html
@@ -1,0 +1,47 @@
+<div class="consultation-row" [class.selected]="isSelected" (click)="onCardClick()">
+    <div class="consultation-cell patient-cell">
+        <div class="cell-header">Patient</div>
+        <div class="patient-info">
+            <span class="patient-name">{{ getPatientName() }}</span>
+            <span class="offline-badge" *ngIf="consultation.patient.isOffline">Offline</span>
+        </div>
+    </div>
+
+    <div class="consultation-cell requested-by-cell">
+        <div class="cell-header">Requested by</div>
+        <span class="cell-value">{{ '-' }}</span>
+    </div>
+
+    <div class="consultation-cell waiting-queue-cell">
+        <div class="cell-header">Waiting queue</div>
+        <span class="cell-value">{{ '-' }}</span>
+    </div>
+
+    <div class="consultation-cell message-cell">
+        <div class="cell-header">Message</div>
+        <span class="cell-value">{{ consultation.lastMessage }}</span>
+    </div>
+
+    <div class="consultation-cell datetime-cell">
+        <div class="cell-header">Time</div>
+        <span class="cell-value">{{ getFormattedDate() }}</span>
+    </div>
+
+    <div class="consultation-cell duration-cell">
+        <div class="cell-header">Participant</div>
+        <span class="cell-value">{{ consultation.participantCount || '-' }}</span>
+    </div>
+
+    <div class="consultation-cell">
+        <app-button [variant]="ButtonVariant.Secondary" [size]="ButtonSize.Small" (click)="onSendInvitation($event)">
+            Send again the invitation
+        </app-button>
+    </div>
+
+    <div class="consultation-cell more-actions-cell">
+        <app-button [variant]="ButtonVariant.Secondary" [size]="ButtonSize.Small" (click)="onCardClick()">
+            <app-svg-icon src="chevron-right" [svgStyle]="{ 'width.px': 16, 'height.px': 16 }" ariaLabel="More actions">
+            </app-svg-icon>
+        </app-button>
+    </div>
+</div>

--- a/practitioner/src/app/components/open-consultation-card/open-consultation-card.component.scss
+++ b/practitioner/src/app/components/open-consultation-card/open-consultation-card.component.scss
@@ -1,0 +1,177 @@
+@use 'sass:color';
+@use './variables' as *;
+
+$spacing-xs: 4px;
+$spacing-sm: 8px;
+$spacing-md: 12px;
+$spacing-lg: 16px;
+$spacing-xl: 20px;
+$border-radius-sm: 4px;
+$border-radius-md: 6px;
+$grid-gap: 12px;
+$grid-gap-sm: 8px;
+$grid-gap-xs: 4px;
+
+.consultation-row {
+    display: grid;
+    grid-template-columns:
+        1fr 1fr 1fr 1fr 150px 150px auto auto;
+    align-items: center;
+    padding: $spacing-lg $spacing-xl;
+    background: $color-background-card;
+    border: 1px solid $color-border-light;
+    border-radius: $border-radius-md;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    gap: $grid-gap;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-height: 60px;
+
+    &:hover {
+        background-color: $color-background;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    }
+
+    &.selected {
+        background-color: $color-selected-bg;
+        border-left: 3px solid $color-primary;
+        border-color: $color-primary;
+    }
+}
+
+.consultation-cell {
+    display: flex;
+    flex-direction: column;
+    padding: $spacing-sm;
+}
+
+.cell-header {
+    font-size: 12px;
+    font-weight: 600;
+    color: $color-description;
+    margin-bottom: $spacing-xs;
+    text-transform: uppercase;
+    letter-spacing: 0.025em;
+}
+
+.cell-value {
+    font-size: 14px;
+    color: $color-text;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.patient-info {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+
+    .patient-name {
+        font-size: 14px;
+        color: $color-text;
+        font-weight: 500;
+    }
+
+    .offline-badge {
+        background-color: color.adjust($color-warning, $lightness: 40%);
+        color: color.adjust($color-warning, $lightness: -20%);
+        padding: 2px $spacing-sm;
+        border-radius: 12px;
+        font-size: 11px;
+        font-weight: 500;
+        text-transform: uppercase;
+    }
+}
+
+.message-cell {
+    .cell-value {
+        white-space: normal;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+        -webkit-box-orient: vertical;
+        line-height: 1.4;
+        max-height: 2.8em;
+    }
+}
+
+.more-actions-cell {
+    justify-content: center;
+
+    app-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+    }
+}
+
+@media (max-width: 1200px) {
+    .consultation-row {
+        grid-template-columns: 1fr 1fr 1fr 180px 120px 300px;
+
+        .requested-by-cell,
+        .waiting-queue-cell {
+            display: none;
+        }
+    }
+}
+
+@media (max-width: 968px) {
+    .consultation-row {
+        grid-template-columns: 1fr 1fr 150px 250px;
+        gap: $grid-gap-sm;
+
+        .requested-by-cell,
+        .waiting-queue-cell,
+        .datetime-cell {
+            display: none;
+        }
+    }
+}
+
+@media (max-width: 640px) {
+    .consultation-row {
+        grid-template-columns: 1fr 200px;
+        padding: $spacing-md $spacing-lg;
+
+        .duration-cell,
+        .message-cell {
+            display: none;
+        }
+    }
+
+    .consultation-cell {
+        padding: $spacing-xs;
+    }
+
+    .cell-header {
+        font-size: 11px;
+    }
+
+    .cell-value {
+        font-size: 13px;
+    }
+}
+
+.consultation-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px;
+    color: $color-description;
+}
+
+.consultation-empty {
+    text-align: center;
+    padding: 40px;
+    color: $color-empty-state-text;
+    background: $color-empty-state-bg;
+    border-radius: $border-radius-md;
+}

--- a/practitioner/src/app/components/open-consultation-card/open-consultation-card.component.spec.ts
+++ b/practitioner/src/app/components/open-consultation-card/open-consultation-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OpenConsultationCardComponent } from './open-consultation-card.component';
+
+describe('OpenConsultationCardComponent', () => {
+  let component: OpenConsultationCardComponent;
+  let fixture: ComponentFixture<OpenConsultationCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OpenConsultationCardComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OpenConsultationCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/practitioner/src/app/components/open-consultation-card/open-consultation-card.component.ts
+++ b/practitioner/src/app/components/open-consultation-card/open-consultation-card.component.ts
@@ -1,0 +1,44 @@
+import { Component, Input, Output, EventEmitter, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ButtonComponent } from '../../components/ui/button/button.component';
+import { ButtonVariant, ButtonSize } from '../../constants/button.enums';
+import { SvgIconComponent } from '../../shared/components/svg-icon.component';
+import {
+  OpenConsultationService,
+} from '../../services/consultations/open-consultation.service';
+import { OpenConsultation } from '../../dtos/consultations/open-consultation.dto';
+@Component({
+  selector: 'app-open-consultation-card',
+  standalone: true,
+  imports: [CommonModule, ButtonComponent, SvgIconComponent],
+  templateUrl: './open-consultation-card.component.html',
+  styleUrls: ['./open-consultation-card.component.scss'],
+})
+export class OpenConsultationCardComponent {
+  @Input() consultation!: OpenConsultation;
+  @Input() isSelected: boolean = false;
+  @Output() consultationClicked = new EventEmitter<OpenConsultation>();
+  @Output() sendInvitation = new EventEmitter<number>();
+
+  readonly ButtonVariant = ButtonVariant;
+  readonly ButtonSize = ButtonSize;
+
+  constructor(public openConsultationService: OpenConsultationService) {}
+
+  onCardClick(): void {
+    this.consultationClicked.emit(this.consultation);
+  }
+
+  onSendInvitation(event: Event): void {
+    event.stopPropagation();
+    this.sendInvitation.emit(this.consultation.id);
+  }
+
+  getPatientName(): string {
+    return `${this.consultation.patient.firstName} ${this.consultation.patient.lastName}`;
+  }
+
+  getFormattedDate(): string {
+    return this.openConsultationService.formatDate(this.consultation.startedAt);
+  }
+}

--- a/practitioner/src/app/components/open-consultation-panel/open-consultation-panel.component.html
+++ b/practitioner/src/app/components/open-consultation-panel/open-consultation-panel.component.html
@@ -1,0 +1,95 @@
+<div class="detail-panel open">
+    <div class="panel-header">
+        <h2>Open Consultation Details</h2>
+        <app-button [variant]="ButtonVariant.Secondary" [size]="ButtonSize.Small" (click)="onClose()" class="close-button" ariaLabel="Close panel">
+            <app-svg-icon src="x" [svgStyle]="{ 'width.px': 16, 'height.px': 16 }" ariaLabel="Close icon">
+            </app-svg-icon>
+        </app-button>
+    </div>
+
+    <div class="panel-content">
+        <section class="detail-section">
+            <div class="section-header">
+                <h3>General Information</h3>
+                <app-button [variant]="ButtonVariant.Primary" [size]="ButtonSize.Small" (click)="onInviteColleague()">
+                    Invite a colleague
+                </app-button>
+            </div>
+
+            <div class="info-grid">
+                <div class="info-item">
+                    <span class="label">Patient name</span>
+                    <div class="patient-name-row">
+                        <span class="value">{{ getPatientName() }}</span>
+                        <span class="offline-badge" *ngIf="consultation.patient.isOffline">Offline</span>
+                        <app-button [variant]="ButtonVariant.Secondary" [size]="ButtonSize.Small" class="email-btn">
+                            <app-svg-icon src="mail" [svgStyle]="{ 'width.px': 16, 'height.px': 16 }"
+                                ariaLabel="Email icon">
+                            </app-svg-icon>
+                        </app-button>
+                    </div>
+                </div>
+
+                <div class="info-item">
+                    <span class="label">Sex</span>
+                    <span class="value">{{ getSexDisplay() }}</span>
+                </div>
+
+                <div class="info-item">
+                    <span class="label">Requested by</span>
+                    <span class="value">{{ '-' }}</span>
+                </div>
+
+                <div class="info-item">
+                    <span class="label">Waiting queue</span>
+                    <span class="value">{{'-' }}</span>
+                </div>
+
+                <div class="info-item">
+                    <span class="label">Message</span>
+                    <span class="value">{{ consultation.lastMessage }}</span>
+                </div>
+
+                <div class="info-item">
+                    <span class="label">Time</span>
+                    <span class="value">{{ getFormattedDate() }}</span>
+                </div>
+
+                <div class="info-item">
+                    <span class="label">Participant</span>
+                    <span class="value">{{ consultation.participantCount || '-' }}</span>
+                </div>
+
+                <div class="info-item">
+                    <span class="label">Patient invited at</span>
+                    <span class="value">{{ getFormattedInviteDate() }}</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="detail-section">
+            <h3>Actions</h3>
+            <div class="action-buttons">
+                <app-button [variant]="ButtonVariant.Secondary" [size]="ButtonSize.Medium" (click)="onSendInvitation()">
+                    Send again the invitation
+                </app-button>
+            </div>
+        </section>
+
+        <section class="detail-section">
+            <h3>Additional Information</h3>
+            <div class="placeholder-section">
+                <p>Additional consultation details and controls will appear here</p>
+            </div>
+        </section>
+    </div>
+
+    <div class="panel-footer">
+        <app-button [variant]="ButtonVariant.Primary" [size]="ButtonSize.Medium" (click)="onCloseConsultation()">
+            Close
+        </app-button>
+        <app-button [variant]="ButtonVariant.Primary" [size]="ButtonSize.Medium" (click)="onJoin()">
+            Resume
+        </app-button>
+    </div>
+</div>

--- a/practitioner/src/app/components/open-consultation-panel/open-consultation-panel.component.scss
+++ b/practitioner/src/app/components/open-consultation-panel/open-consultation-panel.component.scss
@@ -1,0 +1,266 @@
+@use 'sass:color';
+@use './variables' as *;
+
+$panel-width: 600px;
+$panel-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+$panel-transition: right 0.3s ease;
+$panel-z-index: 1000;
+$border-radius-sm: 6px;
+$border-radius-md: 8px;
+$border-radius-lg: 12px;
+$spacing-xs: 4px;
+$spacing-sm: 8px;
+$spacing-md: 12px;
+$spacing-lg: 16px;
+$spacing-xl: 20px;
+$spacing-2xl: 32px;
+
+.detail-panel {
+    position: fixed;
+    top: 0;
+    right: -$panel-width;
+    width: $panel-width;
+    height: 100vh;
+    background: $color-background-card;
+    box-shadow: $panel-shadow;
+    transition: $panel-transition;
+    z-index: $panel-z-index;
+    display: flex;
+    flex-direction: column;
+
+    &.open {
+        right: 0;
+    }
+
+    @media (max-width: 768px) {
+        width: 100vw;
+        right: -100vw;
+    }
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: $spacing-xl;
+    border-bottom: 1px solid $color-border-light;
+    background: $color-empty-state-bg;
+
+    h2 {
+        margin: 0;
+        font-size: 20px;
+        font-weight: 600;
+        color: $color-heading;
+    }
+}
+
+.close-button {
+    background: none;
+    border: none;
+    padding: $spacing-sm;
+    cursor: pointer;
+    border-radius: $border-radius-sm;
+    transition: background-color 0.2s;
+    color: $color-description;
+
+    &:hover {
+        background-color: $color-border-light;
+        color: $color-text;
+    }
+}
+
+.panel-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: $spacing-xl;
+}
+
+.detail-section {
+    margin-bottom: $spacing-2xl;
+
+    h3 {
+        font-size: $spacing-lg;
+        font-weight: 600;
+        color: $color-heading;
+        margin: 0 0 $spacing-lg 0;
+        padding-bottom: $spacing-sm;
+        border-bottom: 2px solid $color-surface;
+    }
+
+    .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: $spacing-lg;
+
+        h3 {
+            border-bottom: none;
+            padding-bottom: 0;
+            margin: 0;
+        }
+    }
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: $spacing-lg;
+}
+
+.info-item {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-xs;
+
+    .patient-name-row {
+        display: flex;
+        align-items: center;
+        gap: $spacing-sm;
+
+        .value {
+            margin: 0;
+        }
+
+        .offline-badge {
+            background-color: color.adjust($color-warning, $lightness: 40%);
+            color: color.adjust($color-warning, $lightness: -20%);
+            padding: 2px $spacing-sm;
+            border-radius: $border-radius-lg;
+            font-size: 11px;
+            font-weight: 500;
+            text-transform: uppercase;
+        }
+
+        .email-btn {
+            padding: $spacing-xs;
+            min-width: auto;
+            height: auto;
+        }
+    }
+}
+
+.label {
+    font-size: 12px;
+    font-weight: 500;
+    color: $color-description;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.value {
+    font-size: 14px;
+    color: $color-text;
+    font-weight: 500;
+    line-height: 1.4;
+}
+
+.action-buttons {
+    display: flex;
+    gap: $spacing-md;
+    flex-wrap: wrap;
+}
+
+.placeholder-section {
+    background-color: $color-empty-state-bg;
+    border: 1px dashed $color-border-light;
+    border-radius: $border-radius-md;
+    padding: $spacing-2xl $spacing-xl;
+    text-align: center;
+
+    p {
+        color: $color-description;
+        font-size: 14px;
+        margin: 0;
+    }
+}
+
+.panel-footer {
+    padding: $spacing-xl;
+    border-top: 1px solid $color-border-light;
+    background: $color-empty-state-bg;
+    display: flex;
+    gap: $spacing-md;
+
+    app-button {
+        flex: 1;
+    }
+}
+
+.loading-state,
+.error-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 200px;
+    text-align: center;
+}
+
+.loading-spinner {
+    width: $spacing-2xl;
+    height: $spacing-2xl;
+    border: 3px solid $color-surface;
+    border-top: 3px solid $color-primary;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-bottom: $spacing-lg;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.error-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: $spacing-md;
+}
+
+
+@media (max-width: 1024px) {
+    .detail-panel {
+        width: 500px;
+        right: -500px;
+    }
+}
+
+@media (max-width: 640px) {
+    .panel-header {
+        padding: $spacing-lg;
+    }
+
+    .panel-content {
+        padding: $spacing-lg;
+    }
+
+    .panel-footer {
+        padding: $spacing-lg;
+        flex-direction: column;
+    }
+
+    .detail-section {
+        margin-bottom: $spacing-xl;
+    }
+
+    .info-grid {
+        grid-template-columns: 1fr;
+        gap: $spacing-md;
+    }
+
+    .section-header {
+        flex-direction: column;
+        gap: $spacing-md;
+        align-items: flex-start;
+    }
+
+    .action-buttons {
+        flex-direction: column;
+    }
+}

--- a/practitioner/src/app/components/open-consultation-panel/open-consultation-panel.component.spec.ts
+++ b/practitioner/src/app/components/open-consultation-panel/open-consultation-panel.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OpenConsultationPanelComponent } from './open-consultation-panel.component';
+
+describe('OpenConsultationPanelComponent', () => {
+  let component: OpenConsultationPanelComponent;
+  let fixture: ComponentFixture<OpenConsultationPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OpenConsultationPanelComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OpenConsultationPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/practitioner/src/app/components/open-consultation-panel/open-consultation-panel.component.ts
+++ b/practitioner/src/app/components/open-consultation-panel/open-consultation-panel.component.ts
@@ -1,0 +1,78 @@
+import { Component, Input, Output, EventEmitter, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ButtonComponent } from '../../components/ui/button/button.component';
+import { ButtonVariant, ButtonSize } from '../../constants/button.enums';
+import { SvgIconComponent } from '../../shared/components/svg-icon.component';
+import {
+  OpenConsultationService,
+} from '../../services/consultations/open-consultation.service';
+import { OpenConsultation } from '../../dtos/consultations/open-consultation.dto';
+@Component({
+  selector: 'app-open-consultation-panel',
+  standalone: true,
+  imports: [CommonModule, ButtonComponent, SvgIconComponent],
+  templateUrl: './open-consultation-panel.component.html',
+  styleUrls: ['./open-consultation-panel.component.scss'],
+})
+export class OpenConsultationPanelComponent {
+  @Input() consultation!: OpenConsultation;
+  @Output() close = new EventEmitter<void>();
+  @Output() joinConsultation = new EventEmitter<number>();
+  @Output() closeConsultation = new EventEmitter<number>();
+  @Output() inviteColleague = new EventEmitter<number>();
+  @Output() sendInvitation = new EventEmitter<number>();
+
+  readonly ButtonVariant = ButtonVariant;
+  readonly ButtonSize = ButtonSize;
+
+  constructor(private openConsultationService: OpenConsultationService) {}
+
+  onClose(): void {
+    this.close.emit();
+  }
+
+  onJoin(): void {
+    this.joinConsultation.emit(this.consultation.id);
+  }
+
+  onCloseConsultation(): void {
+    this.closeConsultation.emit(this.consultation.id);
+  }
+
+  onInviteColleague(): void {
+    this.inviteColleague.emit(this.consultation.id);
+  }
+
+  onSendInvitation(): void {
+    this.sendInvitation.emit(this.consultation.id);
+  }
+
+  getPatientName(): string {
+    return `${this.consultation.patient.firstName} ${this.consultation.patient.lastName}`;
+  }
+
+  getFormattedDate(): string {
+    return this.openConsultationService.formatDate(this.consultation.startedAt);
+  }
+
+  getFormattedInviteDate(): string {
+    const date = new Date(this.consultation.startedAt);
+    const day = date.getDate();
+    const month = date.toLocaleString('default', { month: 'short' });
+    const year = date.getFullYear();
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+
+    return `${day} ${month} ${year} ${hours}:${minutes}`;
+  }
+
+  getSexDisplay(): string {
+    const sexMap: { [key: string]: string } = {
+      MALE: 'Male',
+      FEMALE: 'Female',
+      OTHER: 'Other',
+    };
+    const sex = this.consultation.patient.sex;
+    return sex ? (sexMap[sex] || sex) : '';
+  }
+}

--- a/practitioner/src/app/constants/month.enum.ts
+++ b/practitioner/src/app/constants/month.enum.ts
@@ -1,0 +1,14 @@
+export enum months {
+  Jan = 'Jan',
+  Feb = 'Feb',
+  Mar = 'Mar',
+  Apr = 'Apr',
+  May = 'May',
+  Jun = 'Jun',
+  Jul = 'Jul',
+  Aug = 'Aug',
+  Sep = 'Sep',
+  Oct = 'Oct',
+  Nov = 'Nov',
+  Dec = 'Dec',
+};

--- a/practitioner/src/app/constants/user-sex.enum.ts
+++ b/practitioner/src/app/constants/user-sex.enum.ts
@@ -1,0 +1,5 @@
+export enum UserSex {
+  MALE = 'MALE',
+  FEMALE = 'FEMALE',
+  OTHER = 'OTHER',
+}

--- a/practitioner/src/app/dtos/consultations/consultation-dashboard-response.dto.ts
+++ b/practitioner/src/app/dtos/consultations/consultation-dashboard-response.dto.ts
@@ -1,0 +1,27 @@
+import { OpenConsultationPatient } from "./open-consultation.dto";
+
+export interface WaitingRoomItem {
+  id: number;
+  patientInitials: string;
+  joinTime: string | null;
+  language: string | null;
+}
+
+export interface WaitingRoomResponse {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  waitingRooms: WaitingRoomItem[];
+  totalCount: number;
+}
+
+export interface OpenConsultationItem {
+  id: number;
+  patient: OpenConsultationPatient;
+  timeSinceStart: string;
+  participantCount: number;
+  lastMessage: string | null;
+  status: string;
+  startedAt: string;
+  groupName: string | null;
+}

--- a/practitioner/src/app/dtos/consultations/consultation-history-response.dto.ts
+++ b/practitioner/src/app/dtos/consultations/consultation-history-response.dto.ts
@@ -3,6 +3,7 @@ import { UserResponseDto } from '../users/user-response.dto';
 import { ParticipantResponseDto } from './participant-response.dto';
 
 export interface ConsultationHistoryResponseDto {
+  ownerId: number | null | undefined;
   id: number;
   scheduledDate?: string | null;
   createdAt?: string | null;
@@ -10,7 +11,6 @@ export interface ConsultationHistoryResponseDto {
   closedAt?: string | null;
   createdBy?: number | null;
   groupId?: number | null;
-  owner?: number | null;
   whatsappTemplateId?: number | null;
   status: ConsultationStatus;
   patient: UserResponseDto;

--- a/practitioner/src/app/dtos/consultations/index.ts
+++ b/practitioner/src/app/dtos/consultations/index.ts
@@ -2,3 +2,5 @@ export * from './consultation-history-response.dto';
 export * from './consultation-detail-response.dto';
 export * from './participant-response.dto';
 export * from './message-response.dto';
+export * from './open-consultation.dto';
+export * from './consultation-dashboard-response.dto';

--- a/practitioner/src/app/dtos/consultations/open-consultation.dto.ts
+++ b/practitioner/src/app/dtos/consultations/open-consultation.dto.ts
@@ -1,0 +1,58 @@
+import { Cons } from "rxjs";
+import { ConsultationStatus } from "../../constants/consultation-status.enum";
+import { UserSex } from "../../constants/user-sex.enum";
+
+export interface OpenConsultationPatient {
+  id: number;
+  firstName: string | null;
+  lastName: string | null;
+  initials: string;
+  sex: UserSex | null;
+  isOffline: boolean;
+}
+
+export interface OpenConsultation {
+  id: number;
+  patient: OpenConsultationPatient;
+  timeSinceStart: string;
+  participantCount: number;
+  lastMessage: string | null;
+  status: ConsultationStatus;
+  startedAt: Date;
+  groupName: string | null;
+}
+
+export interface OpenConsultationResponse {
+  consultations: OpenConsultation[];
+  total: number;
+  currentPage: number;
+  totalPages: number;
+  limit: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  status: string;
+  statusCode: number;
+  message: string;
+  timestamp: string;
+  data: T;
+}
+
+export interface JoinConsultationResponse {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  consultationId: number;
+  sessionUrl?: string;
+}
+
+export interface CloseConsultationResponse {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  consultationId: number;
+  closedAt: Date;
+}

--- a/practitioner/src/app/dtos/consultations/open-consultation.dto.ts
+++ b/practitioner/src/app/dtos/consultations/open-consultation.dto.ts
@@ -45,7 +45,7 @@ export interface JoinConsultationResponse {
   success: boolean;
   statusCode: number;
   message: string;
-  consultationId: number;
+  consultationId?: number;
   sessionUrl?: string;
 }
 

--- a/practitioner/src/app/mocks/consultation-history.service.ts
+++ b/practitioner/src/app/mocks/consultation-history.service.ts
@@ -84,7 +84,7 @@ export const mockConsultations: Consultation[] = [
     closedAt: new Date('2024-02-15T10:45:00Z'),
     createdBy: 1,
     groupId: 201,
-    owner: 2,
+    ownerId: 2,
     whatsappTemplateId: 301,
     status: ConsultationStatus.COMPLETED,
   },
@@ -96,7 +96,7 @@ export const mockConsultations: Consultation[] = [
     closedAt: null,
     createdBy: 3,
     groupId: 202,
-    owner: 2,
+    ownerId: 2,
     whatsappTemplateId: null,
     status: ConsultationStatus.COMPLETED,
   },
@@ -108,7 +108,7 @@ export const mockConsultations: Consultation[] = [
     closedAt: null,
     createdBy: 1,
     groupId: null,
-    owner: 2,
+    ownerId: 2,
     whatsappTemplateId: 302,
     status: ConsultationStatus.SCHEDULED,
   },
@@ -120,13 +120,12 @@ export const mockConsultations: Consultation[] = [
     closedAt: null,
     createdBy: 5,
     groupId: null,
-    owner: null,
+    ownerId: 2,
     whatsappTemplateId: null,
     status: ConsultationStatus.CANCELLED,
   },
 ];
 
-// Mock Participants
 export const mockParticipants: Participant[] = [
   {
     id: 1001,
@@ -184,7 +183,6 @@ export const mockParticipants: Participant[] = [
   },
 ];
 
-// Mock Messages
 export const mockMessages: Message[] = [
   {
     id: 2001,
@@ -244,7 +242,6 @@ export const mockMessages: Message[] = [
   },
 ];
 
-// Mock Consultation History Items
 export const mockConsultationHistory: ConsultationHistoryItem[] = [
   {
     consultation: mockConsultations[0],
@@ -266,7 +263,6 @@ export const mockConsultationHistory: ConsultationHistoryItem[] = [
   },
 ];
 
-// Mock Consultation Details
 export const mockConsultationDetails: ConsultationDetail[] = [
   {
     consultation: mockConsultations[0],
@@ -284,7 +280,6 @@ export const mockConsultationDetails: ConsultationDetail[] = [
   },
 ];
 
-// Helper functions to get specific mock data
 export const getMockUserById = (id: number): User | undefined => {
   return mockUsers.find((user) => user.id === id);
 };

--- a/practitioner/src/app/models/consultations/consultation.model.ts
+++ b/practitioner/src/app/models/consultations/consultation.model.ts
@@ -23,7 +23,7 @@ export interface Consultation {
   closedAt?: Date | null;
   createdBy?: number | null;
   groupId?: number | null;
-  owner?: number | null;
+  ownerId?: number | null;
   whatsappTemplateId?: number | null;
   status: ConsultationStatus;
 }

--- a/practitioner/src/app/open-consultations/open-consultations.component.html
+++ b/practitioner/src/app/open-consultations/open-consultations.component.html
@@ -1,1 +1,90 @@
-<p>open-consultations works!</p>
+<div class="consultation-history-page">
+    <div class="page-header">
+        <div class="header-content">
+            <h2>OPENED CONSULTATIONS</h2>
+        </div>
+        <div class="header-actions">
+            <span class="consultation-count">{{ totalConsultations }} Open</span>
+        </div>
+    </div>
+
+    <div class="main-content">
+        <div class="consultation-list" [class.with-panel]="showRightPanel">
+            @if (isLoading) {
+            <div class="loading-state">
+                <div class="loading-spinner"></div>
+                <p>Loading consultations...</p>
+            </div>
+            }
+
+            @if (!isLoading && consultations.length === 0) {
+            <div class="empty-state">
+                <div class="empty-message">
+                    <h3>No Open Consultations</h3>
+                    <p>
+                        No open consultations at the moment. New consultations will appear here when patients request
+                        them.
+                    </p>
+                </div>
+            </div>
+            }
+
+            @if (!isLoading && consultations.length > 0) {
+            <div class="consultations-grid">
+                @for (consultation of consultations; track consultation.id) {
+                <app-open-consultation-card [consultation]="consultation"
+                    [isSelected]="selectedConsultation?.id === consultation.id"
+                    (consultationClicked)="onConsultationClick($event)" (sendInvitation)="onSendInvitation($event)">
+                </app-open-consultation-card>
+                }
+            </div>
+            }
+
+            @if (totalPages > 1) {
+            <div class="pagination">
+                <app-button [variant]="ButtonVariant.Secondary" [size]="ButtonSize.Small" [disabled]="currentPage === 1"
+                    (click)="onPageChange(currentPage - 1)">
+                    Previous
+                </app-button>
+
+                <div class="page-numbers">
+                    @for (page of getPaginationPages(); track page) {
+                    <button class="page-number" [class.active]="page === currentPage" (click)="onPageChange(page)">
+                        {{ page }}
+                    </button>
+                    }
+                </div>
+
+                <app-button [variant]="ButtonVariant.Secondary" [size]="ButtonSize.Small"
+                    [disabled]="currentPage === totalPages" (click)="onPageChange(currentPage + 1)">
+                    Next
+                </app-button>
+            </div>
+            }
+        </div>
+
+        <app-overlay [isOpen]="showRightPanel" (closed)="closeRightPanel()">
+            <app-open-consultation-panel *ngIf="showRightPanel && selectedConsultation"
+                [consultation]="selectedConsultation" (close)="closeRightPanel()"
+                (joinConsultation)="onJoinConsultation($event)" (closeConsultation)="onCloseConsultation($event)"
+                (inviteColleague)="onSendInvitation($event)" (sendInvitation)="onSendInvitation($event)">
+            </app-open-consultation-panel>
+        </app-overlay>
+    </div>
+
+    @if (!isLoading) {
+    <div class="results-summary">
+        <button class="page-button" [disabled]="currentPage === 1" (click)="onPageChange(currentPage - 1)"
+            aria-label="Previous page">
+            ‹
+        </button>
+
+        <span class="page-indicator">{{ currentPage }}</span>
+
+        <button class="page-button" [disabled]="currentPage === totalPages" (click)="onPageChange(currentPage + 1)"
+            aria-label="Next page">
+            ›
+        </button>
+    </div>
+    }
+</div>

--- a/practitioner/src/app/open-consultations/open-consultations.component.scss
+++ b/practitioner/src/app/open-consultations/open-consultations.component.scss
@@ -1,0 +1,311 @@
+@use './variables' as *;
+
+.consultation-history-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background-color: $color-page-bg;
+    padding: 24px;
+
+    .results-summary {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 20px;
+    }
+
+    .page-button {
+        width: 32px;
+        height: 32px;
+        border: 1px solid $color-page-button-border;
+        border-radius: 50%;
+        background-color: $color-page-button-bg;
+        color: $color-text-light;
+        font-size: 16px;
+        line-height: 1;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        transition: all 0.2s ease;
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        &:not(:disabled):hover {
+            background-color: $color-page-button-hover;
+        }
+    }
+
+    .page-indicator {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background-color: $color-page-indicator-bg;
+        color: $color-text-inverse;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-weight: 600;
+    }
+
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 32px;
+        padding-bottom: 24px;
+        border-bottom: 1px solid $color-page-border;
+
+        .header-content {
+            flex: 1;
+
+            h1 {
+                font-size: 32px;
+                font-weight: 700;
+                color: $color-page-title;
+                margin: 0 0 8px 0;
+                line-height: 1.2;
+            }
+
+            .header-description {
+                font-size: 16px;
+                color: $color-page-subtitle;
+                margin: 0;
+                line-height: 1.5;
+                max-width: 600px;
+            }
+        }
+
+        .header-actions {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+
+            .consultation-count {
+                background-color: $color-error;
+                color: $color-text-inverse;
+                padding: 6px 12px;
+                border-radius: 20px;
+                font-size: 14px;
+                font-weight: 600;
+                min-width: 60px;
+                text-align: center;
+                letter-spacing: 0.5px;
+            }
+        }
+    }
+
+    .main-content {
+        display: flex;
+        gap: 24px;
+        flex: 1;
+        overflow: hidden;
+    }
+
+    .consultation-list {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        background-color: $color-background-card;
+        border-radius: 12px;
+        box-shadow: 0 1px 3px $color-card-shadow;
+        overflow: hidden;
+        transition: all 0.3s ease;
+
+        &.with-panel {
+            flex: 0 0 60%;
+        }
+
+        .loading-state {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 80px 20px;
+            color: $color-text-light;
+
+            .loading-spinner {
+                width: 40px;
+                height: 40px;
+                border: 3px solid $color-loading-spinner-bg;
+                border-top: 3px solid $color-loading-spinner;
+                border-radius: 50%;
+                animation: spin 1s linear infinite;
+                margin-bottom: 16px;
+            }
+
+            p {
+                font-size: 16px;
+                margin: 0;
+            }
+        }
+
+        .empty-state {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 80px 20px;
+            text-align: center;
+
+            .empty-message {
+                max-width: 400px;
+
+                .empty-icon {
+                    font-size: 64px;
+                    margin-bottom: 24px;
+                    display: block;
+                    opacity: 0.5;
+                    color: $color-empty-state-text;
+                }
+
+                h3 {
+                    font-size: 20px;
+                    font-weight: 600;
+                    color: $color-list-header-text;
+                    margin: 0 0 12px 0;
+                }
+
+                p {
+                    font-size: 14px;
+                    color: $color-text-light;
+                    margin: 0 0 24px 0;
+                    line-height: 1.6;
+                }
+            }
+        }
+
+        .consultations-grid {
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            overflow-y: auto;
+            flex: 1;
+        }
+
+        .pagination {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+            padding: 20px;
+            border-top: 1px solid $color-pagination-border;
+            background-color: $color-pagination-bg;
+
+            .page-numbers {
+                display: flex;
+                gap: 4px;
+
+                .page-number {
+                    padding: 8px 12px;
+                    border: 1px solid $color-pagination-button-border;
+                    background-color: $color-pagination-button-bg;
+                    color: $color-pagination-button;
+                    font-size: 14px;
+                    border-radius: 6px;
+                    cursor: pointer;
+                    transition: all 0.2s ease;
+
+                    &:hover {
+                        background-color: $color-pagination-button-hover;
+                        border-color: $color-pagination-button-hover-border;
+                    }
+
+                    &.active {
+                        background-color: $color-pagination-active-bg;
+                        border-color: $color-pagination-active-bg;
+                        color: $color-pagination-active;
+                    }
+                }
+            }
+        }
+    }
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+// Responsive Design
+@media (max-width: 1200px) {
+    .consultation-history-page {
+        .main-content {
+            flex-direction: column;
+
+            .consultation-list {
+                &.with-panel {
+                    flex: 1;
+                }
+            }
+        }
+    }
+}
+
+@media (max-width: 768px) {
+    .consultation-history-page {
+        padding: 16px;
+
+        .page-header {
+            flex-direction: column;
+            gap: 16px;
+            align-items: stretch;
+
+            .header-content {
+                h1 {
+                    font-size: 24px;
+                }
+
+                .header-description {
+                    font-size: 14px;
+                }
+            }
+
+            .header-actions {
+                justify-content: flex-start;
+            }
+        }
+
+        .main-content {
+            gap: 16px;
+        }
+
+        .consultation-list {
+            .consultations-grid {
+                padding: 16px;
+                gap: 12px;
+            }
+
+            .pagination {
+                padding: 16px;
+
+                .page-numbers {
+                    .page-number {
+                        padding: 6px 10px;
+                        font-size: 12px;
+                    }
+                }
+            }
+        }
+    }
+}
+
+@media (max-width: 480px) {
+    .consultation-history-page {
+        .pagination {
+            .page-numbers {
+                display: none;
+            }
+        }
+    }
+}

--- a/practitioner/src/app/open-consultations/open-consultations.component.ts
+++ b/practitioner/src/app/open-consultations/open-consultations.component.ts
@@ -1,11 +1,170 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Subject, takeUntil } from 'rxjs';
+import {
+  OpenConsultationService,
+} from '../services/consultations/open-consultation.service';
+import { OpenConsultation } from '../dtos/consultations/open-consultation.dto';
+import { Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { ButtonComponent } from '../components/ui/button/button.component';
+import { ButtonVariant, ButtonSize } from '../constants/button.enums';
+import { OpenConsultationCardComponent } from '../components/open-consultation-card/open-consultation-card.component';
+import { OpenConsultationPanelComponent } from '../components/open-consultation-panel/open-consultation-panel.component';
+import { OverlayComponent } from '../components/overlay/overlay.component';
 
 @Component({
   selector: 'app-open-consultations',
-  imports: [],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ButtonComponent,
+    OpenConsultationCardComponent,
+    OpenConsultationPanelComponent,
+    OverlayComponent,
+  ],
   templateUrl: './open-consultations.component.html',
-  styleUrl: './open-consultations.component.scss'
+  styleUrls: ['./open-consultations.component.scss'],
 })
-export class OpenConsultationsComponent {
+export class OpenConsultationsComponent implements OnInit, OnDestroy {
+  consultations: OpenConsultation[] = [];
+  selectedConsultation: OpenConsultation | null = null;
+  isLoading: boolean = false;
+  currentPage: number = 1;
+  totalPages: number = 1;
+  totalConsultations: number = 0;
+  showRightPanel: boolean = false;
 
+  readonly ButtonVariant = ButtonVariant;
+  readonly ButtonSize = ButtonSize;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private openConsultationService: OpenConsultationService,
+    private router: Router,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.loadConsultations();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  loadConsultations(): void {
+    this.isLoading = true;
+    this.openConsultationService
+      .getOpenConsultations(this.currentPage)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (response) => {
+          this.consultations = response.consultations;
+          this.totalConsultations = response.total;
+          this.currentPage = response.currentPage;
+          this.totalPages = response.totalPages;
+          this.isLoading = false;
+        },
+        error: (error) => {
+          console.error('Error loading consultations:', error);
+          this.isLoading = false;
+        },
+      });
+  }
+
+  onConsultationClick(consultation: OpenConsultation): void {
+    console.log('Consultation clicked:', consultation);
+    this.selectedConsultation = consultation;
+    this.showRightPanel = true;
+    this.cdr.detectChanges();
+  }
+
+  onSendInvitation(consultationId: number): void {
+    this.openConsultationService
+      .sendInvitation(consultationId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (response) => {
+          if (response.success) {
+            console.log('Invitation sent successfully');
+            this.loadConsultations();
+          }
+        },
+        error: (error) => {
+          console.error('Error sending invitation:', error);
+        },
+      });
+  }
+
+  onJoinConsultation(consultationId: number): void {
+    const practitionerId = 1; 
+    this.openConsultationService
+      .joinConsultation(consultationId, practitionerId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (response) => {
+          if (response.success && response.sessionUrl) {
+            this.router.navigate([response.sessionUrl]);
+          }
+        },
+        error: (error) => {
+          console.error('Error joining consultation:', error);
+        },
+      });
+  }
+
+  onCloseConsultation(consultationId: number): void {
+    if (confirm('Are you sure you want to close this consultation?')) {
+      const practitionerId = 1; 
+      this.openConsultationService
+        .closeConsultation(consultationId, practitionerId)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: (response) => {
+            if (response.success) {
+              this.loadConsultations();
+              this.closeRightPanel();
+            }
+          },
+          error: (error) => {
+            console.error('Error closing consultation:', error);
+          },
+        });
+    }
+  }
+
+  closeRightPanel(): void {
+    this.showRightPanel = false;
+    this.selectedConsultation = null;
+  }
+
+  onPageChange(page: number): void {
+    if (page >= 1 && page <= this.totalPages) {
+      this.currentPage = page;
+      this.loadConsultations();
+    }
+  }
+
+  getPaginationPages(): number[] {
+    const pages: number[] = [];
+    const maxVisiblePages = 5;
+
+    let startPage = Math.max(
+      1,
+      this.currentPage - Math.floor(maxVisiblePages / 2)
+    );
+    let endPage = Math.min(this.totalPages, startPage + maxVisiblePages - 1);
+
+    if (endPage - startPage < maxVisiblePages - 1) {
+      startPage = Math.max(1, endPage - maxVisiblePages + 1);
+    }
+
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(i);
+    }
+
+    return pages;
+  }
 }

--- a/practitioner/src/app/open-consultations/open-consultations.component.ts
+++ b/practitioner/src/app/open-consultations/open-consultations.component.ts
@@ -105,8 +105,14 @@ export class OpenConsultationsComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (response) => {
-          if (response.success && response.sessionUrl) {
-            this.router.navigate([response.sessionUrl]);
+          if (response.success) {
+            if (response.sessionUrl) {
+              window.location.href = response.sessionUrl;
+            } else {
+              this.router.navigate(['/consultation', consultationId]);
+            }
+          } else {
+            console.error('Failed to join consultation:', response.message);
           }
         },
         error: (error) => {

--- a/practitioner/src/app/open-consultations/open-consultations.component.ts
+++ b/practitioner/src/app/open-consultations/open-consultations.component.ts
@@ -57,7 +57,7 @@ export class OpenConsultationsComponent implements OnInit, OnDestroy {
   loadConsultations(): void {
     this.isLoading = true;
     this.openConsultationService
-      .getOpenConsultations(this.currentPage)
+      .getOpenConsultations(3, this.currentPage)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (response) => {

--- a/practitioner/src/app/services/consultations/consultation-history.service.ts
+++ b/practitioner/src/app/services/consultations/consultation-history.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
+import { tap } from 'rxjs/operators';
 // Domain Models
 import {
   ConsultationHistoryItem,
@@ -40,11 +40,12 @@ export class ConsultationHistoryService {
       .set('practitionerId', practitionerId.toString())
       .set('status', ConsultationStatus.COMPLETED);
 
-    return this.http
-      .get<ConsultationHistoryResponseDto[]>(`${this.apiUrl}/history`, {
-        params,
+    return this.http.get<unknown>(`${this.apiUrl}/history`, { params }).pipe(
+      map((res) => {
+        const rows = (res as any).rows ?? (res as any).data ?? res;
+        return Array.isArray(rows) ? rows.map(this.mapToHistoryItem) : [];
       })
-      .pipe(map((rows) => rows.map(this.mapToHistoryItem)));
+    );
   }
 
   getConsultationDetail(
@@ -90,7 +91,7 @@ export class ConsultationHistoryService {
       closedAt: end || null,
       createdBy: data.createdBy,
       groupId: data.groupId,
-      owner: data.owner,
+      ownerId: data.ownerId,
       whatsappTemplateId: data.whatsappTemplateId,
       status: data.status,
     };

--- a/practitioner/src/app/services/consultations/consultation.service.ts
+++ b/practitioner/src/app/services/consultations/consultation.service.ts
@@ -1,77 +1,105 @@
 import { Injectable } from '@angular/core';
-import { of, type Observable } from 'rxjs';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { of, type Observable, map } from 'rxjs';
 import type { Consultation } from '../../models/consultations/consultation.model';
 import { ConsultationStatus } from '../../constants/consultation-status.enum';
 import { formatConsultationTime } from '../../utils/date-utils';
-
+import type {
+  WaitingRoomResponse,
+  WaitingRoomItem,
+  OpenConsultationItem,
+} from '../../dtos/consultations/consultation-dashboard-response.dto';
+import type {
+  ApiResponse,
+  OpenConsultationResponse,
+} from '../../dtos/consultations/open-consultation.dto';
 @Injectable({
   providedIn: 'root',
 })
 export class ConsultationService {
-  private readonly mockConsultations: Consultation[] = [
-    {
-      id: 1,
-      scheduledDate: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
-      createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
-      startedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
-      closedAt: new Date(Date.now() - 23 * 60 * 60 * 1000),
-      createdBy: 101,
-      owner: 201,
-      groupId: 301,
-      whatsappTemplateId: 1001,
-      status: ConsultationStatus.ACTIVE,
-    },
-    {
-      id: 2,
-      scheduledDate: new Date(),
-      createdAt: new Date(Date.now() - 30 * 60 * 1000),
-      startedAt: new Date(),
-      closedAt: new Date(),
-      createdBy: 102,
-      owner: 202,
-      groupId: 302,
-      status: ConsultationStatus.WAITING,
-    },
-    {
-      id: 3,
-      scheduledDate: new Date(Date.now() + 2 * 60 * 60 * 1000),
-      createdAt: new Date(Date.now() - 60 * 60 * 1000),
-      startedAt: new Date(),
-      closedAt: new Date(),
-      createdBy: 103,
-      owner: 203,
-      groupId: 303,
-      status: ConsultationStatus.WAITING,
-    },
-    {
-      id: 4,
-      scheduledDate: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
-      createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
-      startedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
-      closedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
-      createdBy: 104,
-      owner: 204,
-      groupId: 304,
-      status: ConsultationStatus.COMPLETED,
-    },
-  ];
+  private baseUrl = 'http://localhost:3000/api/v1/consultation';
 
-  constructor() {}
+  private readonly practitionerId = 1;
+
+  constructor(private http: HttpClient) {}
 
   getWaitingConsultations(): Observable<Consultation[]> {
-    return of(
-      this.mockConsultations.filter(
-        (c) => c.status === ConsultationStatus.WAITING
-      )
+    const params = new HttpParams().set(
+      'userId',
+      this.practitionerId.toString()
     );
+
+    return this.http
+      .get<ApiResponse<WaitingRoomResponse>>(`${this.baseUrl}/waiting-room`, {
+        params,
+      })
+      .pipe(
+        map((response) => {
+          // Convert WaitingRoomItem[] to Consultation[] format
+          return response.data.waitingRooms.map((item) =>
+            this.convertWaitingRoomToConsultation(item)
+          );
+        })
+      );
   }
 
+
   getOpenConsultations(): Observable<Consultation[]> {
-    return of(
-      this.mockConsultations.filter(
-        (c) => c.status === ConsultationStatus.ACTIVE
-      )
-    );
+    const params = new HttpParams()
+      .set('practitionerId', this.practitionerId.toString())
+      .set('page', '1')
+      .set('limit', '50'); 
+
+    return this.http
+      .get<ApiResponse<OpenConsultationResponse>>(`${this.baseUrl}/open`, {
+        params,
+      })
+      .pipe(
+        map((response) => {
+          return response.data.consultations.map((item) =>
+            this.convertOpenConsultationToConsultation(item)
+          );
+        })
+      );
+  }
+
+
+  private convertWaitingRoomToConsultation(
+    item: WaitingRoomItem
+  ): Consultation {
+    return {
+      id: item.id,
+      scheduledDate: new Date(),
+      createdAt: new Date(),
+      startedAt: item.joinTime ? new Date(item.joinTime) : new Date(),
+      closedAt: undefined,
+      createdBy: this.practitionerId,
+      ownerId: this.practitionerId,
+      groupId: undefined,
+      whatsappTemplateId: undefined,
+      status: ConsultationStatus.WAITING,
+    };
+  }
+
+  private convertOpenConsultationToConsultation(
+    item: OpenConsultationItem | any
+  ): Consultation {
+    const startedAtDate = item.startedAt instanceof Date ? item.startedAt : new Date(item.startedAt);
+    return {
+      id: item.id,
+      scheduledDate: startedAtDate,
+      createdAt: startedAtDate,
+      startedAt: startedAtDate,
+      closedAt: undefined,
+      createdBy: this.practitionerId,
+      ownerId: this.practitionerId,
+      groupId: undefined,
+      whatsappTemplateId: undefined,
+      status:
+        item.status === 'ACTIVE'
+          ? ConsultationStatus.ACTIVE
+          : ConsultationStatus.WAITING,
+    };
   }
 
   formatTime(date: Date): string {

--- a/practitioner/src/app/services/consultations/open-consultation.service.ts
+++ b/practitioner/src/app/services/consultations/open-consultation.service.ts
@@ -1,0 +1,174 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { delay, map, catchError } from 'rxjs/operators';
+import {
+  OpenConsultationResponse,
+  OpenConsultation,
+  JoinConsultationResponse,
+  CloseConsultationResponse,
+  OpenConsultationPatient,
+  ApiResponse,
+} from '../../dtos/consultations/open-consultation.dto';
+import { months } from '../../constants/month.enum';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OpenConsultationService {
+  private apiUrl = 'http://localhost:3000/api/v1/consultation';
+
+  constructor(private http: HttpClient) {}
+
+  getOpenConsultations(
+    practitionerId: number,
+    page: number = 1,
+    limit: number = 10
+  ): Observable<OpenConsultationResponse> {
+    const params = new HttpParams()
+      .set('practitionerId', practitionerId.toString())
+      .set('page', page.toString())
+      .set('limit', limit.toString());
+
+    return this.http
+      .get<ApiResponse<OpenConsultationResponse>>(`${this.apiUrl}/open`, {
+        params,
+      })
+      .pipe(
+        map((response) => response.data),
+        catchError((error) => {
+          console.error('Error fetching open consultations:', error);
+          return of({
+            consultations: [],
+            total: 0,
+            currentPage: page,
+            totalPages: 0,
+            limit,
+            hasNextPage: false,
+            hasPreviousPage: false,
+          });
+        })
+      );
+  }
+
+  getConsultationDetails(
+    consultationId: number,
+    practitionerId: number
+  ): Observable<OpenConsultation | null> {
+    const params = new HttpParams().set(
+      'practitionerId',
+      practitionerId.toString()
+    );
+
+    return this.http
+      .get<ApiResponse<OpenConsultation>>(
+        `${this.apiUrl}/open/${consultationId}/details`,
+        { params }
+      )
+      .pipe(
+        map((response) => response.data),
+        catchError((error) => {
+          console.error('Error fetching consultation details:', error);
+          return of(null);
+        })
+      );
+  }
+
+  joinConsultation(
+    consultationId: number,
+    practitionerId: number
+  ): Observable<JoinConsultationResponse> {
+    const params = new HttpParams().set(
+      'practitionerId',
+      practitionerId.toString()
+    );
+
+    const body = { consultationId };
+
+    return this.http
+      .post<ApiResponse<JoinConsultationResponse>>(
+        `${this.apiUrl}/open/join`,
+        body,
+        { params }
+      )
+      .pipe(
+        map((response) => response.data),
+        catchError((error) => {
+          console.error('Error joining consultation:', error);
+          // Return mock success response
+          return of({
+            success: false,
+            statusCode: 500,
+            message: 'Failed to join consultation',
+            consultationId,
+          });
+        })
+      );
+  }
+
+  closeConsultation(
+    consultationId: number,
+    practitionerId: number,
+    reason?: string
+  ): Observable<CloseConsultationResponse> {
+    const params = new HttpParams().set(
+      'practitionerId',
+      practitionerId.toString()
+    );
+
+    const body = {
+      consultationId,
+      ...(reason && { reason }),
+    };
+
+    return this.http
+      .post<ApiResponse<CloseConsultationResponse>>(
+        `${this.apiUrl}/open/close`,
+        body,
+        { params }
+      )
+      .pipe(
+        map((response) => response.data),
+        catchError((error) => {
+          console.error('Error closing consultation:', error);
+          return of({
+            success: false,
+            statusCode: 500,
+            message: 'Failed to close consultation',
+            consultationId,
+            closedAt: new Date(),
+          });
+        })
+      );
+  }
+
+  sendInvitation(consultationId: number): Observable<{ success: boolean }> {
+    return of({ success: true }).pipe(delay(500));
+  }
+
+  formatDate(date: Date | string): string {
+    const d = new Date(date);
+    return `${months[d.getMonth() as unknown as keyof typeof months]} ${d.getDate()}`;
+  }
+
+  formatTime(date: Date | string): string {
+    const d = new Date(date);
+    return d.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  }
+
+  getPatientDisplayName(patient: OpenConsultationPatient): string {
+    if (patient.firstName && patient.lastName) {
+      return `${patient.firstName} ${patient.lastName}`;
+    } else if (patient.firstName) {
+      return patient.firstName;
+    } else if (patient.lastName) {
+      return patient.lastName;
+    } else {
+      return patient.initials || 'Unknown Patient';
+    }
+  }
+}

--- a/practitioner/src/app/services/consultations/open-consultation.service.ts
+++ b/practitioner/src/app/services/consultations/open-consultation.service.ts
@@ -95,7 +95,6 @@ export class OpenConsultationService {
         map((response) => response.data),
         catchError((error) => {
           console.error('Error joining consultation:', error);
-          // Return mock success response
           return of({
             success: false,
             statusCode: 500,

--- a/practitioner/src/app/services/consultations/open-consultation.service.ts
+++ b/practitioner/src/app/services/consultations/open-consultation.service.ts
@@ -92,7 +92,15 @@ export class OpenConsultationService {
         { params }
       )
       .pipe(
-        map((response) => response.data),
+        map((response) => {
+          return {
+            success: response.data.success,
+            statusCode: response.data.statusCode,
+            message: response.data.message,
+            consultationId: response.data.consultationId,
+            sessionUrl: response.data.sessionUrl, 
+          };
+        }),
         catchError((error) => {
           console.error('Error joining consultation:', error);
           return of({
@@ -100,6 +108,7 @@ export class OpenConsultationService {
             statusCode: 500,
             message: 'Failed to join consultation',
             consultationId,
+            sessionUrl: undefined,
           });
         })
       );

--- a/practitioner/src/assets/svg/x.svg
+++ b/practitioner/src/assets/svg/x.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>


### PR DESCRIPTION
 
## Description
This PR implements the new **Open Consultations** panel under the sidebar for practitioners, fulfilling the “Open Consultations view” user story. Now, practitioners can:

* **See all active consultations**
  – Fetches consultations where the current user is the owner, `startedAt` is set, and `closedAt` is null
  – Displays patient name (or initials placeholder), time since start, participant count, and a preview of the last message/status
<img width="1470" alt="Screenshot 2025-07-05 at 1 27 48 AM" src="https://github.com/user-attachments/assets/65f568bf-7c59-47a0-ba10-e97b2726e679" />
<img width="1470" alt="Screenshot 2025-07-05 at 1 28 02 AM" src="https://github.com/user-attachments/assets/51efde34-24d0-46c6-97f1-191b06520bf9" />

