### PR TITLE
Suppress Mediasoup verbose load logs in development to avoid loop

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,7 +5,7 @@ import { AppModule } from './app.module';
 import { ConfigService } from './config/config.service';
 import { CustomLoggerService } from './logger/logger.service';
 import { Environment } from './config/environment.enum';
-import * as passport from 'passport';
+import passport from 'passport'; 
 import session from 'express-session';
 import { join } from 'path';
 import { NestExpressApplication } from '@nestjs/platform-express';

--- a/backend/src/mediasoup/mediasoup-session.service.ts
+++ b/backend/src/mediasoup/mediasoup-session.service.ts
@@ -40,6 +40,8 @@ export class MediasoupSessionService implements OnModuleDestroy {
     message: string,
     meta: Record<string, any> = {},
   ) {
+
+    if (level === 'verbose' && process.env.NODE_ENV !== 'production') return;
     const logEntry = {
       timestamp: new Date().toISOString(),
       service: 'mediasoup-session',

--- a/backend/src/mediasoup/mediasoup.module.ts
+++ b/backend/src/mediasoup/mediasoup.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { ConfigModule } from 'src/config/config.module'; 
 import { MediasoupServerService } from './mediasoup.service';
 import { MediasoupSessionService } from './mediasoup-session.service';
 import { MediasoupServerController } from './mediasoup.controller';
@@ -7,19 +8,21 @@ import { DatabaseModule } from 'src/database/database.module';
 import { UserModule } from 'src/user/user.module';
 import { AuthModule } from 'src/auth/auth.module';
 import { ConsultationModule } from 'src/consultation/consultation.module';
-ConsultationModule
 
 @Module({
-  imports: [DatabaseModule, UserModule, AuthModule, forwardRef(() => ConsultationModule),],
+  imports: [
+    ConfigModule, 
+    DatabaseModule,
+    UserModule,
+    AuthModule,
+    forwardRef(() => ConsultationModule),
+  ],
   controllers: [MediasoupServerController],
   providers: [
     MediasoupServerService,
     MediasoupSessionService,
     MediasoupGateway,
   ],
-  exports: [
-    MediasoupServerService,
-    MediasoupSessionService, 
-  ],
+  exports: [MediasoupServerService, MediasoupSessionService],
 })
 export class MediasoupModule {}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,6 +16,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "esModuleInterop": true 
   }
 }


### PR DESCRIPTION
This PR updates the logStructured method in MediasoupSessionService to suppress verbose messages ("Broadcasted load" and "Received load update") unless running in production. This cleans up the developer console during local development while keeping logging unchanged for production deployments.