### PR TITLE
feat: Added consultation termination modal component

### DIFF
--- a/practitioner/src/app/components/consultation-termination-modal/consultation-termination-modal.component.html
+++ b/practitioner/src/app/components/consultation-termination-modal/consultation-termination-modal.component.html
@@ -1,0 +1,72 @@
+<div class="termination-overlay" (click)="onClose()">
+  <div class="termination-modal" (click)="$event.stopPropagation()">
+    
+    <header class="termination-modal__header">
+      <h2 class="termination-modal__title">TERMINATE THE CONSULTATION</h2>
+      <button (click)="onClose()" class="termination-modal__close">×</button>
+    </header>
+
+    <div class="termination-modal__body">
+      <div class="termination-options">
+        
+        <div class="termination-option">
+          <div class="termination-option__content">
+            <h3 class="termination-option__title">Close</h3>
+            <p class="termination-option__description">
+              The consultation will be displayed into history during 24 hours and you will not 
+              be able to communication anymore
+            </p>
+          </div>
+          <div class="termination-option__actions">
+            <app-button 
+              [variant]="ButtonVariant.Primary"
+              [size]="ButtonSize.Medium"
+              (click)="onActionSelect(TerminationAction.Close)"
+              class="termination-option__button termination-option__button--close">
+              Close
+            </app-button>
+          </div>
+        </div>
+
+        <div class="termination-option">
+          <div class="termination-option__content">
+            <h3 class="termination-option__title">Terminate but keep opened</h3>
+            <p class="termination-option__description">
+              You will be able to resume the consultation later but the nurse or the 
+              patient will not able to communicate with you anymore.
+            </p>
+          </div>
+          <div class="termination-option__actions">
+            <app-button 
+              [variant]="ButtonVariant.Primary"
+              [size]="ButtonSize.Medium"
+              (click)="onActionSelect(TerminationAction.TerminateButKeepOpen)"
+              class="termination-option__button termination-option__button--terminate">
+              Terminate but keep opened
+            </app-button>
+          </div>
+        </div>
+
+        <div class="termination-option">
+          <div class="termination-option__content">
+            <h3 class="termination-option__title">Stay in the current consultation</h3>
+            <p class="termination-option__description">
+              Don't close the consultation
+            </p>
+          </div>
+          <div class="termination-option__actions">
+            <app-button 
+              [variant]="ButtonVariant.Outline"
+              [size]="ButtonSize.Medium"
+              (click)="onActionSelect(TerminationAction.StayInConsultation)"
+              class="termination-option__button termination-option__button--stay">
+              Stay in the current consultation
+            </app-button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/practitioner/src/app/components/consultation-termination-modal/consultation-termination-modal.component.scss
+++ b/practitioner/src/app/components/consultation-termination-modal/consultation-termination-modal.component.scss
@@ -1,0 +1,202 @@
+@use '../../../styles/variables' as *;
+
+.termination-overlay {
+  position: fixed;
+  inset: 0;
+  background: $color-overlay-bg;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  backdrop-filter: blur(2px);
+}
+
+.termination-modal {
+  position: relative;
+  z-index: 10001;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+  max-width: 900px;
+  width: 90vw;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header */
+.termination-modal__header {
+  padding: 24px 32px;
+  background: white;
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 80px;
+}
+
+.termination-modal__title {
+  font-size: 20px;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.termination-modal__close {
+  background: none;
+  border: none;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 4px;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+
+  &:hover {
+    background: #f3f4f6;
+    color: #374151;
+  }
+}
+
+/* Body */
+.termination-modal__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px;
+}
+
+.termination-options {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 24px;
+  max-width: 100%;
+}
+
+.termination-option {
+  display: flex;
+  flex-direction: column;
+  background: #f9fafb;
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
+  min-height: 280px;
+  justify-content: space-between;
+}
+
+.termination-option__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+}
+
+.termination-option__title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0 0 16px 0;
+  line-height: 1.3;
+}
+
+.termination-option__description {
+  font-size: 14px;
+  color: #6b7280;
+  line-height: 1.5;
+  margin: 0;
+  text-align: center;
+}
+
+.termination-option__actions {
+  display: flex;
+  justify-content: center;
+}
+
+.termination-option__button {
+  min-width: 140px;
+
+  &--close ::ng-deep button {
+    background: #dc2626;
+    border-color: #dc2626;
+    color: white;
+    
+    &:hover {
+      background: #b91c1c;
+      border-color: #b91c1c;
+    }
+  }
+
+  &--terminate ::ng-deep button {
+    background: #2563eb;
+    border-color: #2563eb;
+    color: white;
+    
+    &:hover {
+      background: #1d4ed8;
+      border-color: #1d4ed8;
+    }
+  }
+
+  &--stay ::ng-deep button {
+    background: transparent;
+    border-color: #6b7280;
+    color: #6b7280;
+    
+    &:hover {
+      background: #f3f4f6;
+      border-color: #4b5563;
+      color: #4b5563;
+    }
+  }
+}
+
+/* Responsive design */
+@media (max-width: 1024px) {
+  .termination-options {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
+  .termination-option {
+    min-height: auto;
+    padding: 20px;
+  }
+
+  .termination-modal {
+    width: 95vw;
+    max-height: 95vh;
+    margin: 20px;
+  }
+
+  .termination-modal__header {
+    padding: 20px 24px;
+  }
+
+  .termination-modal__body {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .termination-modal__title {
+    font-size: 16px;
+  }
+
+  .termination-option__title {
+    font-size: 16px;
+  }
+
+  .termination-option__description {
+    font-size: 13px;
+  }
+}

--- a/practitioner/src/app/components/consultation-termination-modal/consultation-termination-modal.component.spec.ts
+++ b/practitioner/src/app/components/consultation-termination-modal/consultation-termination-modal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConsultationTerminationModalComponent } from './consultation-termination-modal.component';
+
+describe('ConsultationTerminationModalComponent', () => {
+  let component: ConsultationTerminationModalComponent;
+  let fixture: ComponentFixture<ConsultationTerminationModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConsultationTerminationModalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ConsultationTerminationModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/practitioner/src/app/components/consultation-termination-modal/consultation-termination-modal.component.ts
+++ b/practitioner/src/app/components/consultation-termination-modal/consultation-termination-modal.component.ts
@@ -1,0 +1,44 @@
+import { Component, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ButtonComponent } from '../ui/button/button.component';
+import { ButtonSize, ButtonVariant } from '../../constants/button.enums';
+
+export enum TerminationAction {
+  Close = 'close',
+  TerminateButKeepOpen = 'terminate_keep_open',
+  StayInConsultation = 'stay'
+}
+
+@Component({
+  selector: 'app-consultation-termination-modal',
+  standalone: true,
+  imports: [CommonModule, ButtonComponent],
+  templateUrl: './consultation-termination-modal.component.html',
+  styleUrls: ['./consultation-termination-modal.component.scss']
+})
+export class ConsultationTerminationModalComponent implements OnInit, OnDestroy {
+  @Output() actionSelected = new EventEmitter<TerminationAction>();
+  @Output() close = new EventEmitter<void>();
+
+  readonly ButtonSize = ButtonSize;
+  readonly ButtonVariant = ButtonVariant;
+  readonly TerminationAction = TerminationAction;
+
+  ngOnInit(): void {
+    document.body.classList.add('modal-open');
+  }
+
+  ngOnDestroy(): void {
+    document.body.classList.remove('modal-open');
+  }
+
+  onActionSelect(action: TerminationAction): void {
+    document.body.classList.remove('modal-open');
+    this.actionSelected.emit(action);
+  }
+
+  onClose(): void {
+    document.body.classList.remove('modal-open');
+    this.close.emit();
+  }
+}


### PR DESCRIPTION
Added Termination modal , its backend api's are already created earlier for closing consultation
<img width="935" height="448" alt="Screenshot 2025-09-09 at 6 53 23 PM" src="https://github.com/user-attachments/assets/da84ef09-73c2-4e99-b1c3-718f7c7c74a3" />

